### PR TITLE
Change BIP101 parameters to do 2 MB in 2016, 4 MB in 2018

### DIFF
--- a/qa/rpc-tests/bigblocks.py
+++ b/qa/rpc-tests/bigblocks.py
@@ -14,8 +14,8 @@ from decimal import Decimal
 CACHE_DIR = "cache_bigblock"
 
 # regression test / testnet fork params:
-FORK_TIME = 1438387200
-FORK_BLOCK_VERSION = 0x20000007
+FORK_TIME = 1393632000
+FORK_BLOCK_VERSION = 0x20000008
 FORK_GRACE_PERIOD = 60*60*24
 
 class BigBlockTest(BitcoinTestFramework):

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -28,9 +28,9 @@ class ForkNotifyTest(BitcoinTestFramework):
                                 ["-blockversion=211"]))
         connect_nodes(self.nodes[1], 0)
 
-        # Node2 mines block.version=0x20000007 blocks
+        # Node2 mines block.version=0x20000008 blocks
         self.nodes.append(start_node(2, self.options.tmpdir,
-                            ["-blockversion=%d"%(0x20000007,)]))
+                            ["-blockversion=%d"%(0x20000008,)]))
         connect_nodes(self.nodes[2], 0)
 
         self.is_network_split = False

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -57,8 +57,8 @@ public:
         // Timestamps for forking consensus rule changes:
         //  Allow bigger blocks
         consensus.nEarliestSizeForkTime = 1456790400; // 01 Mar 2016 00:00:00 UTC
-        // 1MB max blocks before 11 Jan 2016
-        // Then, if miner consensus: 8MB max, doubling every two years
+        // 1MB max blocks before 1 Mar 2016
+        // Then, if miner consensus: 2MB max, doubling over two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years
         consensus.nMaxSizeBase = 2*1000*1000; // 2MB
@@ -163,8 +163,8 @@ public:
         nMaxTipAge = 0x7fffffff;
         nPruneAfterHeight = 1000;
 
-        // 1MB max blocks before 1 Aug 2015
-        // Then, if miner consensus: 8MB max, doubling every two years
+        // 1MB max blocks before 1 Mar 2014
+        // Then, if miner consensus: 2MB max, doubling twice over two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nEarliestSizeForkTime = 1393632000; // 01 Mar 2014 00:00:00 UTC, 2 years ahead of mainnet
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -58,7 +58,7 @@ public:
         //  Allow bigger blocks
         consensus.nEarliestSizeForkTime = 1456790400; // 01 Mar 2016 00:00:00 UTC
         // 1MB max blocks before 1 Mar 2016
-        // Then, if miner consensus: 2MB max, doubling over two years
+        // Then, if miner consensus: 2MB limit to start, doubling over two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years
         consensus.nMaxSizeBase = 2*1000*1000; // 2MB
@@ -164,7 +164,7 @@ public:
         nPruneAfterHeight = 1000;
 
         // 1MB max blocks before 1 Mar 2014
-        // Then, if miner consensus: 2MB max, doubling twice over two years
+        // Then, if miner consensus: 2MB limit to start, doubling twice over two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nEarliestSizeForkTime = 1393632000; // 01 Mar 2014 00:00:00 UTC, 2 years ahead of mainnet
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -56,15 +56,15 @@ public:
 
         // Timestamps for forking consensus rule changes:
         //  Allow bigger blocks
-        consensus.nEarliestSizeForkTime = 1452470400; // 11 Jan 2016 00:00:00 UTC
+        consensus.nEarliestSizeForkTime = 1456790400; // 01 Mar 2016 00:00:00 UTC
         // 1MB max blocks before 11 Jan 2016
         // Then, if miner consensus: 8MB max, doubling every two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years
-        consensus.nMaxSizeBase = 8*1000*1000; // 8MB
-        consensus.nMaxSizeDoublings = 10;
+        consensus.nMaxSizeBase = 2*1000*1000; // 2MB
+        consensus.nMaxSizeDoublings = 1; // end at 4MB
         consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
-        consensus.nSizeForkGracePeriod = 60*60*24*14; // two week grace period after activation
+        consensus.nSizeForkGracePeriod = 60*60*24*28; // four week grace period after activation
 
         /**
          * Build the genesis block. Note that the output of its generation
@@ -166,10 +166,10 @@ public:
         // 1MB max blocks before 1 Aug 2015
         // Then, if miner consensus: 8MB max, doubling every two years
         consensus.nMaxSizePreFork = 1000*1000; // 1MB max pre-fork
-        consensus.nEarliestSizeForkTime = 1438387200; // 1 Aug 2015 00:00:00 UTC
+        consensus.nEarliestSizeForkTime = 1393632000; // 01 Mar 2014 00:00:00 UTC, 2 years ahead of mainnet
         consensus.nSizeDoubleEpoch = 60*60*24*365*2; // two years
-        consensus.nMaxSizeBase = 8*1000*1000; // 8MB
-        consensus.nMaxSizeDoublings = 10;
+        consensus.nMaxSizeBase = 2*1000*1000; // 2MB
+        consensus.nMaxSizeDoublings = 2; // End at 8MB; intentionally different from mainnet
         consensus.nActivateSizeForkMajority = 75; // 75 of 100 to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24; // 1-day grace period
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -10,8 +10,22 @@
 #include "serialize.h"
 #include "uint256.h"
 
-/** Blocks with version fields that have these bits set activate the bigger-block fork */
-const unsigned int SIZE_FORK_VERSION = 0x20000007;
+/** Blocks with version fields that have these bits set activate the bigger-block fork.
+ * - First three bits are 001 to indicate version bits usage.
+ * - Last three bits are 000 because legacy softforks up to version 4 have been deployed.
+ * - BIP101 also uses the bit with value 4 (conflicting with BIP65).
+ * - The next available bit has value 8, so we use that.
+ * - Note to future legacy soft-fork writers: please use something like
+ *       if (nVersion >= new_minimum && !(nVersion ^ 0x20000000 & 0xD0000000 ))
+ *   or
+ *       if ((nVersion & 7 ) >= 5)
+ *   in your tests in order to avoid misinterpreting version bits usage as support for
+ *   your as-yet-unwritten feature, as happened with BIP101 and BIP65.
+ * - This implementation of version bits is incomplete. It needs to change the version
+ *   back to 0x20000000 after either the fork is successful or after some arbitrary
+ *   amount of time has passed (e.g. 2 years).
+ */
+const unsigned int SIZE_FORK_VERSION = 0x20000008;
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
@@ -25,7 +39,7 @@ class CBlockHeader
 public:
     static const int32_t CURRENT_VERSION=SIZE_FORK_VERSION;
     // This code knows the rules for these block versions:
-    static const int32_t UNDERSTOOD_VERSIONS = (SIZE_FORK_VERSION | 3 | 2 | 1);
+    static const int32_t UNDERSTOOD_VERSIONS = (SIZE_FORK_VERSION | 4 | 3 | 2 | 1);
 
     // header
     int32_t nVersion;

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -16,9 +16,9 @@
 #include <boost/test/unit_test.hpp>
 
 // These must match parameters in chainparams.cpp
-static const uint64_t EARLIEST_FORK_TIME = 1452470400; // 11 Jan 2016
+static const uint64_t EARLIEST_FORK_TIME = 1456790400; // 01 Mar 2016 00:00:00 UTC
 static const uint32_t MAXSIZE_PREFORK = 1000*1000;
-static const uint32_t MAXSIZE_POSTFORK = 8*1000*1000;
+static const uint32_t MAXSIZE_POSTFORK = 2*1000*1000;
 static const uint64_t SIZE_DOUBLE_EPOCH = 60*60*24*365*2; // two years
 
 BOOST_FIXTURE_TEST_SUITE(block_size_tests, TestingSetup)


### PR DESCRIPTION
Mainnet parameters are:
  2 MB cap
  ... doubling every two years
  ... for two years
  ... earliest possible chain fork: 1 Mar 2016
  ... after miner supermajority (750/1000 blocks)
  ... and 4 week grace period once supermajority achieved

Testnet parameters are:
  2 MB cap
  ... doubling every two years
  ... for four years
  ... earliest possible chain fork: 1 Mar 2014
  ... after miner supermajority (75/100 blocks)
  ... and 1 day grace period once supermajority achieved
  which effectively means 2x the mainnet cap.
