### PR TITLE
BCIP 103: continuous blocksize increase up to 3MB

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -43,6 +43,7 @@ BITCOIN_TESTS =\
   test/base58_tests.cpp \
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
+  test/block_size_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -191,7 +191,7 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
     uint256 txid(uint256S(strTxid));
 
     static const unsigned int minTxOutSz = 9;
-    static const unsigned int maxVout = MAX_BLOCK_SIZE / minTxOutSz;
+    static const unsigned int maxVout = MaxBlockSize(std::numeric_limits<uint64_t>::max())/ minTxOutSz;
 
     // extract and validate vout
     string strVout = strInput.substr(pos + 1, string::npos);

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,18 +8,24 @@
 
 #include <stdint.h>
 
-static const uint64_t BIP202_FORK_TIME = 1462406400; // May 5 2016, midnight UTC
+static const uint64_t BCIP103_FORK_TIME = 1456790400; // April 01 2016, midnight UTC
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 inline unsigned int MaxBlockSize(uint64_t nTime) {
-    if (nTime < BIP202_FORK_TIME)
+    if (nTime < BCIP01_FORK_TIME)
         return 1000*1000;
 
     // cap for tests
     if (nTime > 4113158400)
         nTime = 4113158400;
 
-    return (2*1000*1000) + (20 * ((nTime - BIP202_FORK_TIME) / 600));
+/** Smooth transition of 30 bytes every 10 minutes, until 3 megabytes is reached */
+    if (((2*1000*1000) + (30 * ((nTime - BCIP01_FORK_TIME) / 600))) <= 3000000) {
+      return (2*1000*1000) + (30 * ((nTime - BCIP01_FORK_TIME) / 600));
+    }
+    if (((2*1000*1000) + (30 * ((nTime - BCIP01_FORK_TIME) / 600))) > 3000000){
+      return 4000000;
+    }
 }
 
 /** The maximum allowed size for a serialized transaction, in bytes */

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,18 +8,18 @@
 
 #include <stdint.h>
 
-static const uint64_t BIP102_FORK_TIME = 1462406400; // May 5 2016, midnight UTC
+static const uint64_t BIP202_FORK_TIME = 1462406400; // May 5 2016, midnight UTC
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 inline unsigned int MaxBlockSize(uint64_t nTime) {
-    if (nTime < BIP102_FORK_TIME)
+    if (nTime < BIP202_FORK_TIME)
         return 1000*1000;
 
     // cap for tests
     if (nTime > 4113158400)
         nTime = 4113158400;
 
-    return (2*1000*1000) + (20 * ((nTime - BIP102_FORK_TIME) / 600));
+    return (2*1000*1000) + (20 * ((nTime - BIP202_FORK_TIME) / 600));
 }
 
 /** The maximum allowed size for a serialized transaction, in bytes */

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,10 +6,30 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include <stdint.h>
+
+static const uint64_t BIP102_FORK_TIME = 1462406400; // May 5 2016, midnight UTC
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 1000000;
+inline unsigned int MaxBlockSize(uint64_t nTime) {
+    if (nTime < BIP102_FORK_TIME)
+        return 1000*1000;
+
+    // cap for tests
+    if (nTime > 4113158400)
+        nTime = 4113158400;
+
+    return (2*1000*1000) + (20 * ((nTime - BIP102_FORK_TIME) / 600));
+}
+
+/** The maximum allowed size for a serialized transaction, in bytes */
+static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
+
 /** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+inline unsigned int MaxBlockSigops(uint64_t nTime) {
+    return MaxBlockSize(nTime) / 50;
+}
+
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2068,12 +2068,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
-    bool fBIP202Enforcing = (pindex->GetBlockTime() >= (int64_t)BIP202_FORK_TIME);
-    if (fBIP202Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))
-        fBIP202Enforcing = false;
+    bool fBCIP01Enforcing = (pindex->GetBlockTime() >= (int64_t)BCIP01_FORK_TIME);
+    if (fBCIP01Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))
+        fBCIP01Enforcing = false;
 
     // TODO
-    (void) fBIP202Enforcing;
+    (void) fBCIP01Enforcing;
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
@@ -3690,7 +3690,7 @@ bool LoadBlockIndex()
     return true;
 }
 
-bool InitBlockIndex(const CChainParams& chainparams) 
+bool InitBlockIndex(const CChainParams& chainparams)
 {
     LOCK(cs_main);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2068,12 +2068,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
-    bool fBIP102Enforcing = (pindex->GetBlockTime() >= (int64_t)BIP102_FORK_TIME);
-    if (fBIP102Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))
-        fBIP102Enforcing = false;
+    bool fBIP202Enforcing = (pindex->GetBlockTime() >= (int64_t)BIP202_FORK_TIME);
+    if (fBIP202Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))
+        fBIP202Enforcing = false;
 
     // TODO
-    (void) fBIP102Enforcing;
+    (void) fBIP202Enforcing;
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2069,7 +2069,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     bool fBIP102Enforcing = (pindex->GetBlockTime() >= (int64_t)BIP102_FORK_TIME);
-    if (fBIP102Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityRejectBlockOutdated, chainparams.GetConsensus()))
+    if (fBIP102Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))
         fBIP102Enforcing = false;
 
     // TODO

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -749,7 +749,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
     if (tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_TRANSACTION_SIZE)
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values
@@ -958,7 +958,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
         // Check that the transaction doesn't have an excessive number of
         // sigops, making it impossible to mine. Since the coinbase transaction
         // itself can contain sigops MAX_STANDARD_TX_SIGOPS is less than
-        // MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
+        // MaxBlockSigops; we still consider this an invalid rather than
         // merely non-standard transaction.
         unsigned int nSigOps = GetLegacySigOpCount(tx);
         nSigOps += GetP2SHSigOpCount(tx, view);
@@ -2068,6 +2068,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
+    bool fBIP102Enforcing = (pindex->GetBlockTime() >= (int64_t)BIP102_FORK_TIME);
+    if (fBIP102Enforcing && block.nVersion >= 5 && !IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityRejectBlockOutdated, chainparams.GetConsensus()))
+        fBIP102Enforcing = false;
+
+    // TODO
+    (void) fBIP102Enforcing;
+
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
 
@@ -2088,7 +2095,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        if (nSigOps > MAX_BLOCK_SIGOPS)
+        if (nSigOps > MaxBlockSigops(pindex->nHeight))
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -2104,7 +2111,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // this is to prevent a "rogue miner" from creating
                 // an incredibly-expensive-to-validate block.
                 nSigOps += GetP2SHSigOpCount(tx, view);
-                if (nSigOps > MAX_BLOCK_SIGOPS)
+                if (nSigOps > MaxBlockSigops(pindex->nHeight))
                     return state.DoS(100, error("ConnectBlock(): too many sigops"),
                                      REJECT_INVALID, "bad-blk-sigops");
             }
@@ -2978,7 +2985,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    unsigned int nMaxSize = MaxBlockSize(block.GetBlockTime());
+    if (block.vtx.empty() || block.vtx.size() > nMaxSize || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > nMaxSize)
         return state.DoS(100, error("CheckBlock(): size limits failed"),
                          REJECT_INVALID, "bad-blk-length");
 
@@ -3003,7 +3011,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     {
         nSigOps += GetLegacySigOpCount(tx);
     }
-    if (nSigOps > MAX_BLOCK_SIGOPS)
+    if (nSigOps > MaxBlockSigops(std::numeric_limits<unsigned int>::max()))
         return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"),
                          REJECT_INVALID, "bad-blk-sigops", true);
 
@@ -3052,6 +3060,11 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // Reject block.nVersion=3 blocks when 95% (75% on testnet) of the network has upgraded:
     if (block.nVersion < 4 && IsSuperMajority(4, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
+        return state.Invalid(error("%s : rejected nVersion=3 block", __func__),
+                             REJECT_OBSOLETE, "bad-version");
+
+    // Reject block.nVersion=4 blocks when 95% (75% on testnet) of the network has upgraded:
+    if (block.nVersion < 5 && IsSuperMajority(5, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
         return state.Invalid(error("%s : rejected nVersion=3 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
 
@@ -3729,7 +3742,8 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
     int nLoaded = 0;
     try {
         // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
-        CBufferedFile blkdat(fileIn, 2*MAX_BLOCK_SIZE, MAX_BLOCK_SIZE+8, SER_DISK, CLIENT_VERSION);
+        unsigned int nAbsoluteMaxBlockSize = MaxBlockSize(std::numeric_limits<uint64_t>::max());
+        CBufferedFile blkdat(fileIn, 2*nAbsoluteMaxBlockSize, nAbsoluteMaxBlockSize+8, SER_DISK, CLIENT_VERSION);
         uint64_t nRewind = blkdat.GetPos();
         while (!blkdat.eof()) {
             boost::this_thread::interruption_point();
@@ -3748,7 +3762,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                     continue;
                 // read size
                 blkdat >> nSize;
-                if (nSize < 80 || nSize > MAX_BLOCK_SIZE)
+                if (nSize < 80 || nSize > nAbsoluteMaxBlockSize)
                     continue;
             } catch (const std::exception&) {
                 // no valid block header found; don't complain

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2095,7 +2095,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        if (nSigOps > MaxBlockSigops(pindex->nHeight))
+        if (nSigOps > MaxBlockSigops(block.nTime))
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -2111,7 +2111,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // this is to prevent a "rogue miner" from creating
                 // an incredibly-expensive-to-validate block.
                 nSigOps += GetP2SHSigOpCount(tx, view);
-                if (nSigOps > MaxBlockSigops(pindex->nHeight))
+                if (nSigOps > MaxBlockSigops(block.nTime))
                     return state.DoS(100, error("ConnectBlock(): too many sigops"),
                                      REJECT_INVALID, "bad-blk-sigops");
             }
@@ -3011,7 +3011,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     {
         nSigOps += GetLegacySigOpCount(tx);
     }
-    if (nSigOps > MaxBlockSigops(std::numeric_limits<unsigned int>::max()))
+    if (nSigOps > MaxBlockSigops(std::numeric_limits<uint64_t>::max()))
         return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"),
                          REJECT_INVALID, "bad-blk-sigops", true);
 

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -153,7 +153,7 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch) {
     if (nTransactions == 0)
         return uint256();
     // check for excessively high numbers of transactions
-    if (nTransactions > MAX_BLOCK_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
+    if (nTransactions > MaxBlockSize(std::numeric_limits<uint64_t>::max()) / 60) // 60 is the lower bound for the size of a serialized CTransaction
         return uint256();
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2124,7 +2124,7 @@ void CNode::RecordBytesSent(uint64_t bytes)
 void CNode::SetMaxOutboundTarget(uint64_t limit)
 {
     LOCK(cs_totalBytesSent);
-    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * MAX_BLOCK_SIZE;
+    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * (1*1000*1000);
     nMaxOutboundLimit = limit;
 
     if (limit > 0 && limit < recommendedMinimum)
@@ -2179,7 +2179,7 @@ bool CNode::OutboundTargetReached(bool historicalBlockServingLimit)
     {
         // keep a large enought buffer to at least relay each block once
         uint64_t timeLeftInCycle = GetMaxOutboundTimeLeftInCycle();
-        uint64_t buffer = timeLeftInCycle / 600 * MAX_BLOCK_SIZE;
+        uint64_t buffer = timeLeftInCycle / 600 * (1*1000*1000);
         if (buffer >= nMaxOutboundLimit || nMaxOutboundTotalBytesSentInCycle >= nMaxOutboundLimit - buffer)
             return true;
     }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -24,7 +24,7 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
+static const unsigned int MAX_STANDARD_TX_SIGOPS = 4000;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /**

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -21,7 +21,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=4;
+    static const int32_t CURRENT_VERSION=5;
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -581,8 +581,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("sigoplimit", (int64_t)MAX_BLOCK_SIGOPS));
-    result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SIZE));
+    result.push_back(Pair("sigoplimit", (int64_t)MaxBlockSigops(pblock->nTime)));
+    result.push_back(Pair("sizelimit", (int64_t)MaxBlockSize(pblock->nTime)));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -86,20 +86,20 @@ BOOST_AUTO_TEST_CASE(TwoMegFork)
     CBlock *pblock = &pblocktemplate->block;
 
     // Before fork time...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 1000*1000)); // 1MB : valid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 1000*1000+1)); // >1MB : invalid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 2*1000*1000)); // 2MB : invalid
+    BOOST_CHECK(TestCheckBlock(*pblock, BCIP01_FORK_TIME-1, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BCIP01_FORK_TIME-1, 1000*1000+1)); // >1MB : invalid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BCIP01_FORK_TIME-1, 2*1000*1000)); // 2MB : invalid
 
     // Exactly at fork time...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME, 1000*1000)); // 1MB : valid
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME, 2*1000*1000)); // 2MB : valid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME, 2*1000*1000+1)); // >2MB : invalid
+    BOOST_CHECK(TestCheckBlock(*pblock, BCIP01_FORK_TIME, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, BCIP01_FORK_TIME, 2*1000*1000)); // 2MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BCIP01_FORK_TIME, 2*1000*1000+1)); // >2MB : invalid
 
     // Fork height + 10 min...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, BCIP01_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
 
     // A year after fork time:
-    unsigned int yearAfter = BIP202_FORK_TIME + (365 * 24 * 60 * 60);
+    unsigned int yearAfter = BCIP01_FORK_TIME + (365 * 24 * 60 * 60);
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 1000*1000)); // 1MB : valid
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 2*1000*1000)); // 2MB : valid
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 3*1000*1000)); // 3MB : valid

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparams.h"
+#include "main.h"
+#include "miner.h"
+#include "pubkey.h"
+#include "uint256.h"
+#include "util.h"
+#include "consensus/consensus.h"
+#include "consensus/validation.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(block_size_tests, TestingSetup)
+
+// Fill block with dummy transactions until it's serialized size is exactly nSize
+static void
+FillBlock(CBlock& block, unsigned int nSize)
+{
+    assert(block.vtx.size() > 0); // Start with at least a coinbase
+
+    unsigned int nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    if (nBlockSize > nSize) {
+        block.vtx.resize(1); // passed in block is too big, start with just coinbase
+        nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    }
+
+    // Create a block that is exactly 1,000,000 bytes, serialized:
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig = CScript() << OP_11;
+    tx.vin[0].prevout.hash = block.vtx[0].GetHash(); // passes CheckBlock, would fail if we checked inputs.
+    tx.vin[0].prevout.n = 0;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1LL;
+    tx.vout[0].scriptPubKey = block.vtx[0].vout[0].scriptPubKey;
+
+    unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+    uint256 txhash = tx.GetHash();
+
+    // ... add copies of tx to the block to get close to 1MB:
+    while (nBlockSize+nTxSize < nSize) {
+        block.vtx.push_back(tx);
+        nBlockSize += nTxSize;
+        tx.vin[0].prevout.hash = txhash; // ... just to make each transaction unique
+        txhash = tx.GetHash();
+    }
+    // Make the last transaction exactly the right size by making the scriptSig bigger.
+    block.vtx.pop_back();
+    nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    unsigned int nFill = nSize - nBlockSize - nTxSize;
+    for (unsigned int i = 0; i < nFill; i++)
+        tx.vin[0].scriptSig << OP_11;
+    block.vtx.push_back(tx);
+    nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    assert(nBlockSize == nSize);
+}
+
+static bool TestCheckBlock(CBlock& block, uint64_t nTime, unsigned int nSize)
+{
+    SetMockTime(nTime);
+    block.nTime = nTime;
+    FillBlock(block, nSize);
+    CValidationState validationState;
+    bool fResult = CheckBlock(block, validationState, false, false) && validationState.IsValid();
+    SetMockTime(0);
+    return fResult;
+}
+
+//
+// Unit test CheckBlock() for conditions around the block size hard fork
+//
+BOOST_AUTO_TEST_CASE(TwoMegFork)
+{
+    const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
+    CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    CBlockTemplate *pblocktemplate;
+
+    LOCK(cs_main);
+
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    CBlock *pblock = &pblocktemplate->block;
+
+    // Before fork time...
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 1000*1000+1)); // >1MB : invalid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 2*1000*1000)); // 2MB : invalid
+
+    // Exactly at fork time...
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME, 2*1000*1000)); // 2MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME, 2*1000*1000+1)); // >2MB : invalid
+
+    // Fork height + 10 min...
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
+
+    // A year after fork time:
+    unsigned int yearAfter = BIP102_FORK_TIME+(365 * 144);
+    BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 2*1000*1000)); // 20MB : valid
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -86,20 +86,20 @@ BOOST_AUTO_TEST_CASE(TwoMegFork)
     CBlock *pblock = &pblocktemplate->block;
 
     // Before fork time...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 1000*1000)); // 1MB : valid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 1000*1000+1)); // >1MB : invalid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME-1, 2*1000*1000)); // 2MB : invalid
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 1000*1000+1)); // >1MB : invalid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME-1, 2*1000*1000)); // 2MB : invalid
 
     // Exactly at fork time...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME, 1000*1000)); // 1MB : valid
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME, 2*1000*1000)); // 2MB : valid
-    BOOST_CHECK(!TestCheckBlock(*pblock, BIP102_FORK_TIME, 2*1000*1000+1)); // >2MB : invalid
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME, 1000*1000)); // 1MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME, 2*1000*1000)); // 2MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, BIP202_FORK_TIME, 2*1000*1000+1)); // >2MB : invalid
 
     // Fork height + 10 min...
-    BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, BIP202_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
 
     // A year after fork time:
-    unsigned int yearAfter = BIP102_FORK_TIME + (365 * 24 * 60 * 60);
+    unsigned int yearAfter = BIP202_FORK_TIME + (365 * 24 * 60 * 60);
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 1000*1000)); // 1MB : valid
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 2*1000*1000)); // 2MB : valid
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 3*1000*1000)); // 3MB : valid

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -99,9 +99,11 @@ BOOST_AUTO_TEST_CASE(TwoMegFork)
     BOOST_CHECK(TestCheckBlock(*pblock, BIP102_FORK_TIME+600, 2*1000*1000+20)); // 2MB+20 : valid
 
     // A year after fork time:
-    unsigned int yearAfter = BIP102_FORK_TIME+(365 * 144);
+    unsigned int yearAfter = BIP102_FORK_TIME + (365 * 24 * 60 * 60);
     BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 1000*1000)); // 1MB : valid
-    BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 2*1000*1000)); // 20MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 2*1000*1000)); // 2MB : valid
+    BOOST_CHECK(TestCheckBlock(*pblock, yearAfter, 3*1000*1000)); // 3MB : valid
+    BOOST_CHECK(!TestCheckBlock(*pblock, yearAfter, 4*1000*1000)); // 4MB : invalid
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Alternative proposal to pull request** https://github.com/bitcoinclassic/bitcoinclassic/pull/5
- increase by 30 bytes per block
- stop at max blocksize 3MB
