### PR TITLE
Add 2mb fork expiration date, version bit test cases, and bugfix

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -58,6 +58,7 @@ public:
         // Allow bigger blocks if:
         consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24*28; // four week grace period after activation
+        consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
 
         /**
          * Build the genesis block. Note that the output of its generation
@@ -158,6 +159,7 @@ public:
 
         consensus.nActivateSizeForkMajority = 75; // 75 of 100 to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24; // 1-day grace period
+        consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1296688602;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -29,9 +29,11 @@ struct Params {
     /** 2MB fork activation parameters */
     int nActivateSizeForkMajority;
     int64_t nSizeForkGracePeriod;
+    int64_t nSizeForkExpiration;
 
     int ActivateSizeForkMajority() const { return nActivateSizeForkMajority; }
     int64_t SizeForkGracePeriod() const { return nSizeForkGracePeriod; }
+    int64_t SizeForkExpiration() const { return nSizeForkExpiration; }
 };
 } // namespace Consensus
 

--- a/src/main.h
+++ b/src/main.h
@@ -548,6 +548,6 @@ uint32_t MaxBlockSighash(uint32_t nBlockTime);
 uint32_t MaxLegacySigops(uint32_t nBlockTime);
 
 /** What forks we are expressing support for */
-uint32_t ForkBits(uint32_t nTime);
+uint32_t ForkBits(uint32_t nTime, const Consensus::Params& consensusParams);
 
 #endif // BITCOIN_MAIN_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,7 +129,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
         CCoinsViewCache view(pcoinsTip);
 
-        pblock->nVersion = BASE_VERSION | ForkBits(pblock->nTime);
+        pblock->nVersion = BASE_VERSION | ForkBits(pblock->nTime, chainparams.GetConsensus());
         // -regtest only: allow overriding block.nVersion with
         // -blockversion=N to test forking scenarios
         if (Params().MineBlocksOnDemand())


### PR DESCRIPTION
- Adds an expiration date to the 2MB fork: Jan 1, 2018. After this date, no more votes will be cast for the fork. Blocks with FORK_BIT_2MB set (e.g. due to a different fork that recycles the bit) and with nTime after the expiration date will not trigger the fork.
- New test cases to ensure that the FORK_BIT_2MB and -vote2mb settings work properly.
- Fixes bug in ForkBits that prevented it from ever voting for the fork. (sizeForkTime.load() < nTime) should have been (nTime < sizeForkTime.load()).
