### PR TITLE
Backport of chainstate obfuscation to avoid spurious antivirus detection

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -27,6 +27,7 @@ testScripts=(
     'merkle_blocks.py'
     'signrawtransactions.py'
     'walletbackup.py'
+    'blockchain.py'
 );
 testScriptsExt=(
     'bigblocks.py'

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test RPC calls related to blockchain state.
+#
+
+import decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    initialize_chain,
+    assert_equal,
+    start_nodes,
+    connect_nodes_bi,
+)
+
+class BlockchainTest(BitcoinTestFramework):
+    """
+    Test blockchain-related RPC calls:
+        - gettxoutsetinfo
+    """
+
+    def setup_chain(self):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain(self.options.tmpdir)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        node = self.nodes[0]
+        res = node.gettxoutsetinfo()
+
+        assert_equal(res[u'total_amount'], decimal.Decimal('8725.00000000'))
+        assert_equal(res[u'transactions'], 200)
+        assert_equal(res[u'height'], 200)
+        assert_equal(res[u'txouts'], 200)
+        assert_equal(res[u'bytes_serialized'], 13924),
+        assert_equal(len(res[u'bestblock']), 64)
+        assert_equal(len(res[u'hash_serialized']), 64)
+
+
+if __name__ == '__main__':
+    BlockchainTest().main()

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,7 @@ BITCOIN_TESTS =\
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \
+  test/leveldbwrapper_tests.cpp \
   test/main_tests.cpp \
   test/mempool_tests.cpp \
   test/miner_tests.cpp \
@@ -71,6 +72,7 @@ BITCOIN_TESTS =\
   test/sighash_tests.cpp \
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
+  test/streams_tests.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/timedata_tests.cpp \

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -9,6 +9,7 @@
 #include "serialize.h"
 #include "streams.h"
 #include "util.h"
+#include "utilstrencodings.h"
 #include "version.h"
 
 #include <boost/filesystem/path.hpp>
@@ -31,8 +32,14 @@ class CLevelDBBatch
 
 private:
     leveldb::WriteBatch batch;
+    const std::vector<unsigned char> obfuscate_key;
 
 public:
+    /**
+     * @param[in] obfuscate_key    XOR data with this key.
+     */
+    CLevelDBBatch(const std::vector<unsigned char>& obfuscate_key) : obfuscate_key(obfuscate_key) { };
+
     template <typename K, typename V>
     void Write(const K& key, const V& value)
     {
@@ -44,6 +51,7 @@ public:
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         ssValue.reserve(ssValue.GetSerializeSize(value));
         ssValue << value;
+        ssValue.Xor(obfuscate_key);
         leveldb::Slice slValue(&ssValue[0], ssValue.size());
 
         batch.Put(slKey, slValue);
@@ -85,8 +93,27 @@ private:
     //! the database itself
     leveldb::DB* pdb;
 
+    //! a key used for optional XOR-obfuscation of the database
+    std::vector<unsigned char> obfuscate_key;
+
+    //! the key under which the obfuscation key is stored
+    static const std::string OBFUSCATE_KEY_KEY;
+    
+    //! the length of the obfuscate key in number of bytes
+    static const unsigned int OBFUSCATE_KEY_NUM_BYTES;
+    
+    std::vector<unsigned char> CreateObfuscateKey() const;
+
 public:
-    CLevelDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    /**
+     * @param[in] path        Location in the filesystem where leveldb data will be stored.
+     * @param[in] nCacheSize  Configures various leveldb cache settings.
+     * @param[in] fMemory     If true, use leveldb's memory environment.
+     * @param[in] fWipe       If true, remove all existing data.
+     * @param[in] obfuscate   If true, store data obfuscated via simple XOR. If false, XOR
+     *                        with a zero'd byte array.
+     */
+    CLevelDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
     ~CLevelDBWrapper();
 
     template <typename K, typename V>
@@ -107,6 +134,7 @@ public:
         }
         try {
             CDataStream ssValue(strValue.data(), strValue.data() + strValue.size(), SER_DISK, CLIENT_VERSION);
+            ssValue.Xor(obfuscate_key);
             ssValue >> value;
         } catch (const std::exception&) {
             return false;
@@ -117,7 +145,7 @@ public:
     template <typename K, typename V>
     bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error)
     {
-        CLevelDBBatch batch;
+        CLevelDBBatch batch(obfuscate_key);
         batch.Write(key, value);
         return WriteBatch(batch, fSync);
     }
@@ -144,7 +172,7 @@ public:
     template <typename K>
     bool Erase(const K& key, bool fSync = false) throw(leveldb_error)
     {
-        CLevelDBBatch batch;
+        CLevelDBBatch batch(obfuscate_key);
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
@@ -159,7 +187,7 @@ public:
 
     bool Sync() throw(leveldb_error)
     {
-        CLevelDBBatch batch;
+        CLevelDBBatch batch(obfuscate_key);
         return WriteBatch(batch, true);
     }
 
@@ -168,6 +196,23 @@ public:
     {
         return pdb->NewIterator(iteroptions);
     }
+
+    /**
+     * Return true if the database managed by this class contains no entries.
+     */
+    bool IsEmpty();
+
+    /**
+     * Accessor for obfuscate_key.
+     */
+    const std::vector<unsigned char>& GetObfuscateKey() const;
+
+    /**
+     * Return the obfuscate_key as a hex-formatted string.
+     */
+    std::string GetObfuscateKeyHex() const;
+
 };
 
 #endif // BITCOIN_LEVELDBWRAPPER_H
+

--- a/src/streams.h
+++ b/src/streams.h
@@ -296,6 +296,29 @@ public:
         data.insert(data.end(), begin(), end());
         clear();
     }
+
+    /**
+     * XOR the contents of this stream with a certain key.
+     *
+     * @param[in] key    The key used to XOR the data in this stream.
+     */
+    void Xor(const std::vector<unsigned char>& key)
+    {
+        if (key.size() == 0) {
+            return;
+        }
+
+        for (size_type i = 0, j = 0; i != size(); i++) {
+            vch[i] ^= key[j++];
+
+            // This potentially acts on very many bytes of data, so it's
+            // important that we calculate `j`, i.e. the `key` index in this
+            // way instead of doing a %, which would effectively be a division
+            // for each byte Xor'd -- much slower than need be.
+            if (j == key.size())
+                j = 0;
+        }
+    }
 };
 
 

--- a/src/test/leveldbwrapper_tests.cpp
+++ b/src/test/leveldbwrapper_tests.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) 2012-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "leveldbwrapper.h"
+#include "uint256.h"
+#include "random.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/assign/std/vector.hpp> // for 'operator+=()'
+#include <boost/assert.hpp>
+#include <boost/test/unit_test.hpp>
+                    
+using namespace std;
+using namespace boost::assign; // bring 'operator+=()' into scope
+using namespace boost::filesystem;
+         
+// Test if a string consists entirely of null characters
+bool is_null_key(const vector<unsigned char>& key) {
+    bool isnull = true;
+
+    for (unsigned int i = 0; i < key.size(); i++)
+        isnull &= (key[i] == '\x00');
+
+    return isnull;
+}
+ 
+BOOST_FIXTURE_TEST_SUITE(leveldbwrapper_tests, BasicTestingSetup)
+                       
+BOOST_AUTO_TEST_CASE(leveldbwrapper)
+{
+    // Perform tests both obfuscated and non-obfuscated.
+    for (int i = 0; i < 2; i++) {
+        bool obfuscate = (bool)i;
+        path ph = temp_directory_path() / unique_path();
+        CLevelDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
+        char key = 'k';
+        uint256 in = GetRandHash();
+        uint256 res;
+
+        // Ensure that we're doing real obfuscation when obfuscate=true
+        BOOST_CHECK(obfuscate != is_null_key(dbw.GetObfuscateKey()));
+
+        BOOST_CHECK(dbw.Write(key, in));
+        BOOST_CHECK(dbw.Read(key, res));
+        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    }
+}
+                       
+// Test batch operations
+BOOST_AUTO_TEST_CASE(leveldbwrapper_batch)
+{
+    // Perform tests both obfuscated and non-obfuscated.
+    for (int i = 0; i < 2; i++) {
+        bool obfuscate = (bool)i;
+        path ph = temp_directory_path() / unique_path();
+        CLevelDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
+
+        char key = 'i';
+        uint256 in = GetRandHash();
+        char key2 = 'j';
+        uint256 in2 = GetRandHash();
+        char key3 = 'k';
+        uint256 in3 = GetRandHash();
+
+        uint256 res;
+        CLevelDBBatch batch(dbw.GetObfuscateKey());
+
+        batch.Write(key, in);
+        batch.Write(key2, in2);
+        batch.Write(key3, in3);
+
+        // Remove key3 before it's even been written
+        batch.Erase(key3);
+
+        dbw.WriteBatch(batch);
+
+        BOOST_CHECK(dbw.Read(key, res));
+        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+        BOOST_CHECK(dbw.Read(key2, res));
+        BOOST_CHECK_EQUAL(res.ToString(), in2.ToString());
+
+        // key3 never should've been written
+        BOOST_CHECK(dbw.Read(key3, res) == false);
+    }
+}
+
+// Test that we do not obfuscation if there is existing data.
+BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
+{
+    // We're going to share this path between two wrappers
+    path ph = temp_directory_path() / unique_path();
+    create_directories(ph);
+
+    // Set up a non-obfuscated wrapper to write some initial data.
+    CLevelDBWrapper* dbw = new CLevelDBWrapper(ph, (1 << 10), false, false, false);
+    char key = 'k';
+    uint256 in = GetRandHash();
+    uint256 res;
+
+    BOOST_CHECK(dbw->Write(key, in));
+    BOOST_CHECK(dbw->Read(key, res));
+    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+
+    // Call the destructor to free leveldb LOCK
+    delete dbw;
+
+    // Now, set up another wrapper that wants to obfuscate the same directory
+    CLevelDBWrapper odbw(ph, (1 << 10), false, false, true);
+
+    // Check that the key/val we wrote with unobfuscated wrapper exists and 
+    // is readable.
+    uint256 res2;
+    BOOST_CHECK(odbw.Read(key, res2));
+    BOOST_CHECK_EQUAL(res2.ToString(), in.ToString());
+
+    BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
+    BOOST_CHECK(is_null_key(odbw.GetObfuscateKey())); // The key should be an empty string
+
+    uint256 in2 = GetRandHash();
+    uint256 res3;
+ 
+    // Check that we can write successfully
+    BOOST_CHECK(odbw.Write(key, in2));
+    BOOST_CHECK(odbw.Read(key, res3));
+    BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
+}
+                        
+// Ensure that we start obfuscating during a reindex.
+BOOST_AUTO_TEST_CASE(existing_data_reindex)
+{
+    // We're going to share this path between two wrappers
+    path ph = temp_directory_path() / unique_path();
+    create_directories(ph);
+
+    // Set up a non-obfuscated wrapper to write some initial data.
+    CLevelDBWrapper* dbw = new CLevelDBWrapper(ph, (1 << 10), false, false, false);
+    char key = 'k';
+    uint256 in = GetRandHash();
+    uint256 res;
+
+    BOOST_CHECK(dbw->Write(key, in));
+    BOOST_CHECK(dbw->Read(key, res));
+    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+
+    // Call the destructor to free leveldb LOCK
+    delete dbw;
+
+    // Simulate a -reindex by wiping the existing data store
+    CLevelDBWrapper odbw(ph, (1 << 10), false, true, true);
+
+    // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
+    uint256 res2;
+    BOOST_CHECK(!odbw.Read(key, res2));
+    BOOST_CHECK(!is_null_key(odbw.GetObfuscateKey()));
+
+    uint256 in2 = GetRandHash();
+    uint256 res3;
+ 
+    // Check that we can write successfully
+    BOOST_CHECK(odbw.Write(key, in2));
+    BOOST_CHECK(odbw.Read(key, res3));
+    BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
+}
+ 
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2012-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "streams.h"
+#include "support/allocators/zeroafterfree.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/assign/std/vector.hpp> // for 'operator+=()'
+#include <boost/assert.hpp>
+#include <boost/test/unit_test.hpp>
+                    
+using namespace std;
+using namespace boost::assign; // bring 'operator+=()' into scope
+
+BOOST_FIXTURE_TEST_SUITE(streams_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
+{
+    std::vector<char> in;
+    std::vector<char> expected_xor;
+    std::vector<unsigned char> key;
+    CDataStream ds(in, 0, 0);
+
+    // Degenerate case
+    
+    key += '\x00','\x00';
+    ds.Xor(key);
+    BOOST_CHECK_EQUAL(
+            std::string(expected_xor.begin(), expected_xor.end()), 
+            std::string(ds.begin(), ds.end()));
+
+    in += '\x0f','\xf0';
+    expected_xor += '\xf0','\x0f';
+    
+    // Single character key
+
+    ds.clear();
+    ds.insert(ds.begin(), in.begin(), in.end());
+    key.clear();
+
+    key += '\xff';
+    ds.Xor(key);
+    BOOST_CHECK_EQUAL(
+            std::string(expected_xor.begin(), expected_xor.end()), 
+            std::string(ds.begin(), ds.end())); 
+    
+    // Multi character key
+
+    in.clear();
+    expected_xor.clear();
+    in += '\xf0','\x0f';
+    expected_xor += '\x0f','\x00';
+                        
+    ds.clear();
+    ds.insert(ds.begin(), in.begin(), in.end());
+
+    key.clear();
+    key += '\xff','\x0f';
+
+    ds.Xor(key);
+    BOOST_CHECK_EQUAL(
+            std::string(expected_xor.begin(), expected_xor.end()), 
+            std::string(ds.begin(), ds.end()));  
+}         
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -40,7 +40,7 @@ void static BatchWriteHashBestChain(CLevelDBBatch &batch, const uint256 &hash) {
     batch.Write(DB_BEST_BLOCK, hash);
 }
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe) {
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true) {
 }
 
 bool CCoinsViewDB::GetCoins(const uint256 &txid, CCoins &coins) const {
@@ -59,7 +59,7 @@ uint256 CCoinsViewDB::GetBestBlock() const {
 }
 
 bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
-    CLevelDBBatch batch;
+    CLevelDBBatch batch(db.GetObfuscateKey());
     size_t count = 0;
     size_t changed = 0;
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
@@ -122,6 +122,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
             if (chType == DB_COINS) {
                 leveldb::Slice slValue = pcursor->value();
                 CDataStream ssValue(slValue.data(), slValue.data()+slValue.size(), SER_DISK, CLIENT_VERSION);
+                ssValue.Xor(db.GetObfuscateKey());
                 CCoins coins;
                 ssValue >> coins;
                 uint256 txhash;
@@ -155,7 +156,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
 }
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
-    CLevelDBBatch batch;
+    CLevelDBBatch batch(GetObfuscateKey());
     for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
@@ -171,7 +172,7 @@ bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
 }
 
 bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
-    CLevelDBBatch batch;
+    CLevelDBBatch batch(GetObfuscateKey());
     for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(make_pair(DB_TXINDEX, it->first), it->second);
     return WriteBatch(batch);
@@ -208,6 +209,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
             if (chType == DB_BLOCK_INDEX) {
                 leveldb::Slice slValue = pcursor->value();
                 CDataStream ssValue(slValue.data(), slValue.data()+slValue.size(), SER_DISK, CLIENT_VERSION);
+                ssValue.Xor(GetObfuscateKey());
                 CDiskBlockIndex diskindex;
                 ssValue >> diskindex;
 
@@ -253,6 +255,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 ssKey >> nVersion;
                 leveldb::Slice slValue = pcursor->value();
                 CDataStream ssValue(slValue.data(), slValue.data()+slValue.size(), SER_DISK, CLIENT_VERSION);
+                ssValue.Xor(GetObfuscateKey());
                 uint256 blockHash;
                 ssValue >> blockHash;
                 forkActivationMap[nVersion] = blockHash;


### PR DESCRIPTION
Cherry-pick from 42cb388167ef78f47a3a440eb651b6938c10f508, but removed BatchWriteCoins/BatchWriteHashBestChain refactoring.
Added xor obfuscation in CCoinsViewDB::GetStats and CBlockTreeDB::LoadBlockIndexGuts.
Added qa/rpc-tests/blockchain.py test and leveldbwrapper_batch test from 14885068726a8e0dc73ffa127225ab80be3e3612.
