### PR TITLE
gitian debian apt builder from bitcoinxt project

### DIFF
--- a/contrib/gitian-debian/README.md
+++ b/contrib/gitian-debian/README.md
@@ -1,0 +1,80 @@
+**Create A Debian Package Installer**
+
+1. Download gitian created bitcoinclassic tar file to bitcoinclassic/contrib/gitian-debian directory:
+
+  ```
+  cd bitcoinclassic/contrib/gitian-debian
+  wget https://github.com/bitcoinclassic/bitcoinclassic/releases/download/v0.11.2.cl1/bitcoin-0.11.2-linux64.tar.gz
+  ```
+
+2. Execute debian installer build script:
+  ```
+  ./build.sh
+  ```
+
+**Test New Debian Package Installer**
+
+1. Install newly created debian package on test debian system:
+
+  ```
+  sudo gdebi bitcoincl-0.11.2.deb
+  ```
+
+2. Verify bitcoin classic daemon installed and started:
+
+  ```
+  sudo systemctl status bitcoincld
+  ```
+
+3. Add your user account to the bitcoin system group:
+   
+  ```
+  sudo usermod -a -G bitcoin <your username>
+  ```
+  
+4. Logout and back into your account so new group assignment takes affect.
+
+5. Verify your username was added to the bitcoin group:
+
+  ```
+  groups
+  ```
+
+6. Test bitcoincl-cli access:
+
+  ```
+  /usr/bin/bitcoincl-cli -conf=/etc/bitcoincl/bitcoin.conf getinfo
+  ```
+  
+7. Test bitcoincl-qt with non-conflicting IP port:
+  
+  ```
+  bitcoincl-qt -listen=0:8444
+  ```
+  
+8. Uninstall bitcoincl without removing config file or data:
+
+  ```
+  sudo apt-get remove bitcoincl
+  ```
+
+9. Uninstall bitcoincl AND remove config file and data:
+
+  ```
+  sudo apt-get purge bitcoincl
+  sudo rm -rf /var/lib/bitcoincl
+  ```
+
+**Non-Interactive Installation**
+
+The bitcoincl debian package uses debconf to ask the user if they want to automatically enable and start the bitcoincld service as part of the package installation. To skip this question for non-interactive installs the following instructions allow you to pre-answer the question. This question is only asked the first time the bitcoincl package is installed and only if the target system has the systemd systemctl binary present and executable.
+
+1. Install ```debconf-utils```
+ ```
+ % sudo apt-get install debconf-utils
+ ```
+
+2. Pre-answer the question, ***true*** to automatically enable and start the ```bitcoincld``` service and ***false*** to not automatically enable and start the service during package install
+ ```
+ % sudo sh -c 'echo "bitcoincl bitcoincl/start_service boolean false" | debconf-set-selections'
+ ```

--- a/contrib/gitian-debian/bitcoin.conf
+++ b/contrib/gitian-debian/bitcoin.conf
@@ -1,0 +1,133 @@
+##
+## bitcoin.conf configuration file. Lines beginning with # are comments.
+##
+ 
+# Network-related settings:
+
+# Run on the test network instead of the real bitcoin network.
+#testnet=0
+
+# Run a regression test network
+#regtest=0
+
+# Connect via a SOCKS5 proxy
+#proxy=127.0.0.1:9050
+
+# Bind to given address and always listen on it. Use [host]:port notation for IPv6
+#bind=<addr>
+
+# Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6
+#whitebind=<addr>
+
+##############################################################
+##            Quick Primer on addnode vs connect            ##
+##  Let's say for instance you use addnode=4.2.2.4          ##
+##  addnode will connect you to and tell you about the      ##
+##    nodes connected to 4.2.2.4.  In addition it will tell ##
+##    the other nodes connected to it that you exist so     ##
+##    they can connect to you.                              ##
+##  connect will not do the above when you 'connect' to it. ##
+##    It will *only* connect you to 4.2.2.4 and no one else.##
+##                                                          ##
+##  So if you're behind a firewall, or have other problems  ##
+##  finding nodes, add some using 'addnode'.                ##
+##                                                          ##
+##  If you want to stay private, use 'connect' to only      ##
+##  connect to "trusted" nodes.                             ##
+##                                                          ##
+##  If you run multiple nodes on a LAN, there's no need for ##
+##  all of them to open lots of connections.  Instead       ##
+##  'connect' them all to one node that is port forwarded   ##
+##  and has lots of connections.                            ##
+##       Thanks goes to [Noodle] on Freenode.               ##
+##############################################################
+
+# Use as many addnode= settings as you like to connect to specific peers
+#addnode=69.164.218.197
+#addnode=10.0.0.2:8333
+
+# Alternatively use as many connect= settings as you like to connect ONLY to specific peers
+#connect=69.164.218.197
+#connect=10.0.0.1:8333
+
+# Listening mode, enabled by default except when 'connect' is being used
+#listen=1
+
+# Maximum number of inbound+outbound connections.
+#maxconnections=
+
+#
+# JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
+#
+
+# server=1 tells Bitcoin-QT and bitcoind to accept JSON-RPC commands
+#server=0
+
+# Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
+# This option can be specified multiple times (default: bind to all interfaces)
+#rpcbind=<addr>
+
+# How many seconds bitcoin will wait for a complete RPC HTTP request.
+# after the HTTP connection is established. 
+#rpctimeout=30
+
+# By default, only RPC connections from localhost are allowed.
+# Specify as many rpcallowip= settings as you like to allow connections from other hosts,
+# either as a single IPv4/IPv6 or with a subnet specification.
+
+# NOTE: opening up the RPC port to hosts outside your local trusted network is NOT RECOMMENDED,
+# because the rpcpassword is transmitted over the network unencrypted.
+
+# server=1 tells Bitcoin-QT to accept JSON-RPC commands.
+# it is also read by bitcoind to determine if RPC should be enabled 
+#rpcallowip=10.1.1.34/255.255.255.0
+#rpcallowip=1.2.3.4/24
+#rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
+
+# Listen for RPC connections on this TCP port:
+#rpcport=8332
+
+# You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
+# running on another host using this option:
+#rpcconnect=127.0.0.1
+
+# Use Secure Sockets Layer (also known as TLS or HTTPS) to communicate
+# with Bitcoin -server or bitcoind
+#rpcssl=1
+
+# OpenSSL settings used when rpcssl=1
+#rpcsslciphers=TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH
+#rpcsslcertificatechainfile=server.cert
+#rpcsslprivatekeyfile=server.pem
+
+# Transaction Fee Changes in 0.10.0
+
+# Send transactions as zero-fee transactions if possible (default: 0)
+#sendfreetransactions=0
+
+# Create transactions that have enough fees (or priority) so they are likely to begin confirmation within n blocks (default: 1).
+# This setting is over-ridden by the -paytxfee option.
+#txconfirmtarget=n
+
+# Miscellaneous options
+
+# Pre-generate this many public/private key pairs, so wallet backups will be valid for
+# both prior transactions and several dozen future transactions.
+#keypool=100
+
+# Pay an optional transaction fee every time you send bitcoins.  Transactions with fees
+# are more likely than free transactions to be included in generated blocks, so may
+# be validated sooner.
+#paytxfee=0.00
+
+# User interface options
+
+# Start Bitcoin minimized
+#min=1
+
+# Minimize to the system tray
+#minimizetotray=1
+
+# You must set rpcuser and rpcpassword to secure the JSON-RPC api
+rpcuser=bitcoincl
+#rpcpassword=YourSuperGreatPasswordNumber_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593

--- a/contrib/gitian-debian/bitcoincld.service
+++ b/contrib/gitian-debian/bitcoincld.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Bitcoin Classic distributed currency daemon
+After=network.target
+
+[Service]
+User=bitcoin
+Group=bitcoin
+
+Type=forking
+PIDFile=/var/lib/bitcoincl/bitcoincld.pid
+ExecStart=/usr/bin/bitcoincld -daemon -pid=/var/lib/bitcoincl/bitcoincld.pid \
+-conf=/etc/bitcoincl/bitcoin.conf -datadir=/var/lib/bitcoincl -disablewallet
+
+Restart=always
+PrivateTmp=true
+TimeoutStopSec=60s
+TimeoutStartSec=2s
+StartLimitInterval=120s
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/gitian-debian/build.sh
+++ b/contrib/gitian-debian/build.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+#  Shell script that converts gitian built binaries into a simple DPKG, which can then be put into an apt repo.
+#
+#  Improvement ideas:
+#  - Install the man page from the source repo.
+#  - Wrap in a script that sends crash reports/core dumps to some issue tracker.
+#  - etc ...
+
+ver=0.11.2
+realver=0.11.2
+
+set +e
+
+# Make working space
+workdir=bitcoincl-$realver
+[ -d $workdir ] && rm -r $workdir
+mkdir $workdir
+cd $workdir
+
+# Extract the tarball to a directory called usr
+tarball=bitcoin-$ver-linux64.tar.gz
+tar xzvf ../$tarball
+mv bitcoin-$ver usr
+
+# copy bitcoincld.service file to lib/systemd/system directory
+mkdir -p lib/systemd/system 
+cp ../bitcoincld.service lib/systemd/system
+
+# copy bitcoin.conf file to etc/bitcoincl
+mkdir -p etc/bitcoincl
+cp ../bitcoin.conf etc/bitcoincl
+
+# create file to force creation of data folder
+mkdir -p var/lib/bitcoincl
+touch var/lib/bitcoincl/.empty
+
+# Rename the binaries so we don't conflict with regular Bitcoin
+mv usr/bin/bitcoind usr/bin/bitcoincld
+mv usr/bin/bitcoin-cli usr/bin/bitcoincl-cli
+mv usr/bin/bitcoin-tx usr/bin/bitcoincl-tx
+mv usr/bin/bitcoin-qt usr/bin/bitcoincl-qt
+
+# Remove unneeded files 
+rm usr/bin/test_bitcoin
+rm usr/bin/test_bitcoin-qt
+rm usr/include/*
+rm usr/lib/*
+
+# Set up debian metadata. There are no dependencies beyond libc and other base DSOs as everything is statically linked.
+
+mkdir DEBIAN
+cat <<EOF >DEBIAN/control
+Package: bitcoincl
+Architecture: amd64
+Description: Bitcoin Classic is a fully verifying Bitcoin node implementation based on the sources of Bitcoin Core.
+Maintainer: Steve Myers <steven.myers@gmail.com>
+Version: $realver
+Depends: debconf, adduser, ntp
+EOF
+
+cat <<EOF >DEBIAN/install
+usr/bin/bitcoincld usr/bin
+usr/bin/bitcoincl-cli usr/bin
+usr/bin/bitcoincl-tx usr/bin
+EOF
+
+cat <<EOF >DEBIAN/conffiles
+lib/systemd/system/bitcoincld.service
+etc/bitcoincl/bitcoin.conf
+var/lib/bitcoincl/.empty
+EOF
+
+# copy templates file to DEBIAN/templates
+cp ../templates DEBIAN/templates
+
+# copy the postinst file to DEBIAN/postinst
+cp ../postinst DEBIAN/postinst
+chmod 0755 DEBIAN/postinst 
+
+# copy the prerm file to DEBIAN/prerm
+cp ../prerm DEBIAN/prerm
+chmod 0755 DEBIAN/prerm 
+
+# copy the postrm file to DEBIAN/postrm
+cp ../postrm DEBIAN/postrm
+chmod 0755 DEBIAN/postrm
+
+cd ..
+
+# Build deb
+dpkg-deb --build $workdir

--- a/contrib/gitian-debian/postinst
+++ b/contrib/gitian-debian/postinst
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+# add random rpc password to bitcoin.conf
+echo "rpcpassword=$(xxd -l 16 -p /dev/urandom)" >> /etc/bitcoincl/bitcoin.conf
+
+# add users
+adduser --system --group --quiet bitcoin
+
+# cleanup permissions
+chown root:root /usr/bin/bitcoincl*
+chown root:root /lib/systemd/system/bitcoincld.service
+chown root:root /etc/bitcoincl
+chown bitcoin:bitcoin /etc/bitcoincl/bitcoin.conf
+chmod ug+r /etc/bitcoincl/bitcoin.conf
+chmod u+w /etc/bitcoincl/bitcoin.conf
+chmod o-rw /etc/bitcoincl/bitcoin.conf
+chown -R bitcoin:bitcoin /var/lib/bitcoincl
+chmod u+rwx /var/lib/bitcoincl
+
+# enable and start bitcoincld service if systemctl exists and is executable
+if [ -x "/bin/systemctl" ]; then
+    db_input high bitcoincl/start_service || true
+    db_go || true
+    db_get bitcoincl/start_service
+    if [ "$RET" = "true" ]; then
+        echo "Enabling bitcoincld.service"
+    	/bin/systemctl enable bitcoincld.service
+        echo "Starting bitcoincld.service"
+    	/bin/systemctl start bitcoincld.service
+    else
+        echo "The bitcoincld.service NOT enabled or started."
+    fi
+else
+    echo "The file '/bin/systemctl' is not executable or found, bitcoincld service not automatically enabled or started"
+fi

--- a/contrib/gitian-debian/postrm
+++ b/contrib/gitian-debian/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+  # Source debconf library
+  . /usr/share/debconf/confmodule
+  # Remove my changes to the db 
+  echo "Purging debconf for bitcoincl"
+  db_purge || true
+fi

--- a/contrib/gitian-debian/prerm
+++ b/contrib/gitian-debian/prerm
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+# stop and disable bitcoincld service if systemctl exists and is executable
+if [ -x "/bin/systemctl" ]; then
+    echo "Stopping bitcoincld.service"
+    /bin/systemctl stop bitcoincld.service
+    echo "Disabling bitcoincld.service"
+    /bin/systemctl disable bitcoincld.service
+fi

--- a/contrib/gitian-debian/templates
+++ b/contrib/gitian-debian/templates
@@ -1,0 +1,4 @@
+Template: bitcoincl/start_service
+Type: boolean
+Default: true
+Description: Automatically enable and start systemd bitcoincld.service?


### PR DESCRIPTION
This is a simple copy and update of the gitian debian apt builder script and support files from the XT project. I called the package bitcioncl so it won't conflict with any bitcoin core or xt installation.  I didn't create the original script but I've been the most recent maintainer and the XT team found it useful so I hope classic will too. If you have any questions or would like any changes I'm happy to help.

Some discussion on my most recent changes [here](https://github.com/bitcoinxt/bitcoinxt/pull/46)

@zander took a look back in August also.
