### PR TITLE
Sighashbytes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1199,6 +1199,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
         }
         LogPrint("txcost", "txcost %s size: %d sigops: %d sighash: %d\n",
                  hash.ToString(), nSize, costTracker.GetSigOps(), costTracker.GetSighashBytes());
+        entry.SetSighashBytes(costTracker.GetSighashBytes());
 
         // Check again against just the consensus-critical mandatory script
         // verification flags, in case of bugs in the standard flags that cause

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -79,7 +79,6 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     if(!pblocktemplate.get())
         return NULL;
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
-    ValidationCostTracker resourceTracker(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max());
 
     // Create coinbase tx
     CMutableTransaction txNew;
@@ -109,6 +108,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     uint64_t nBlockSize = 1000;
     uint64_t nBlockTx = 0;
     unsigned int nBlockSigOps = 100;
+    unsigned int nBlockSighashBytes = 0;
     int lastFewTxs = 0;
     CAmount nFees = 0;
 
@@ -171,6 +171,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
         CTxMemPool::txiter iter;
         uint32_t nMaxLegacySigops = MaxLegacySigops(pblock->nTime);
+        const uint32_t nMaxSighashBytes = MaxBlockSighash(pblock->nTime);
 
         while (mi != mempool.mapTx.get<3>().end() || !clearedTxs.empty())
         {
@@ -244,6 +245,10 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
                 }
                 continue;
             }
+            unsigned int nTxSighashBytes = iter->GetSighashBytes();
+            if (nBlockSighashBytes + nTxSighashBytes > nMaxSighashBytes) {
+                break;
+            }
 
             CAmount nTxFees = iter->GetFee();
             // Added
@@ -253,6 +258,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             nBlockSize += nTxSize;
             ++nBlockTx;
             nBlockSigOps += nTxSigOps;
+            nBlockSighashBytes += nTxSighashBytes;
             nFees += nTxFees;
 
             if (fPrintPriority)
@@ -287,7 +293,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         }
         nLastBlockTx = nBlockTx;
         nLastBlockSize = nBlockSize;
-        LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOps);
+        LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d sighash-bytes: %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOps, nBlockSighashBytes);
 
         // Compute final coinbase transaction.
         txNew.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -25,7 +25,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
                                  bool _spendsCoinbase, unsigned int _sigOps):
     tx(_tx), nFee(_nFee), nTime(_nTime), entryPriority(_entryPriority), entryHeight(_entryHeight),
     hadNoDependencies(poolHasNoInputsOf), inChainInputValue(_inChainInputValue),
-    spendsCoinbase(_spendsCoinbase), sigOpCount(_sigOps)
+    spendsCoinbase(_spendsCoinbase), sigOpCount(_sigOps), sighashBytes(0)
 {
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
     nModSize = tx.CalculateModifiedSize(nTxSize);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -69,6 +69,7 @@ private:
     CAmount inChainInputValue; //! Sum of all txin values that are already in blockchain
     bool spendsCoinbase; //! keep track of transactions that spend a coinbase
     unsigned int sigOpCount; //! Legacy sig ops plus P2SH sig op count
+    unsigned int sighashBytes; //! Signature-hash byte count.
     int64_t feeDelta; //! Used for determining the priority of the transaction for mining in a block
 
     // Information about descendants of this transaction that are in the
@@ -101,6 +102,9 @@ public:
     unsigned int GetSigOpCount() const { return sigOpCount; }
     int64_t GetModifiedFee() const { return nFee + feeDelta; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
+
+    void SetSighashBytes(unsigned int shb) { sighashBytes = shb; }
+    unsigned int GetSighashBytes() const { return sighashBytes; }
 
     // Adjusts the descendant state, if this entry is not dirty.
     void UpdateState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);


### PR DESCRIPTION
Two commits to make mining with classic take into account sighashbytes

The creation of blocks now makes sure we don't exceed the limit allowed per block.

The getblocktemplate json gives the actual limit of sighashbytes and updates sigoplimit to account for the activation of BIP109

Tested the first in a debugger in regtest mode.
Tested the latter on mainnet and the post-fork data on testnet where BIP109 is already allowed.
