### PR TITLE
Increase DEFAULT_BLOCK_MAX_SIZE to 1MB

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;


### PR DESCRIPTION
We need this so miners do not accidentally mine 750KB blocks after upgrading to Classic.
