### PR TITLE
Don't send full transactions with a merkleblock if already known

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4251,9 +4251,11 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                             // they must either disconnect and retry or request the full block.
                             // Thus, the protocol spec specified allows for us to provide duplicate txn here,
                             // however we MUST always provide at least what the remote peer needs
+                            LOCK(pfrom->cs_inventory);
                             typedef std::pair<unsigned int, uint256> PairType;
                             BOOST_FOREACH(PairType& pair, merkleBlock.vMatchedTxn)
-                                pfrom->PushMessage(NetMsgType::TX, block.vtx[pair.first]);
+                                if (!pfrom->filterInventoryKnown.contains(pair.second))
+                                    pfrom->PushMessage(NetMsgType::TX, block.vtx[pair.first]);
                         }
                         // else
                             // no response


### PR DESCRIPTION
In merkleblock response, don't include transactions if they were already seen on the peer connection.

This long-standing optimization was removed in https://github.com/bitcoin/bitcoin/pull/7133.  The reason for the removal was that tracking of inventory already known to the peer was expanded and converted to a bloom filter with false-positive rate of 1e-6, whereas previously it was a simple set.

The use of a bloom filter in the already-seen check introduces a 1e-6 chance that a transaction will not be sent along with the merkleblock, even when it has not actually been seen before.  Nevertheless, the optimization should be reinstated for the following reasons:
- Consistency with `RelayTransaction`, which retains the optimization
- It is all that's needed for Classic to fully serve XT-style thin blocks (client support is separate)
- SPV clients should be prepared to handle a merkleblock which is not accompanied by full transactions for every txid they may need

I have corresponded with the maintainers of the most popular P2P SPV clients, here is a summary:
- [breadwallet](https://github.com/breadwallet/breadwallet): @voisine reports that breadwallet already detects this condition and disconnects the peer.  This is effective because the next connection will have a freshly randomized bloom filter and a fresh 1e-6 fp rate.  He was going to check that the peer (us) is not banned in this case.
- [bitcoinj](https://github.com/bitcoinj/bitcoinj): @schildbach has opened an issue https://github.com/bitcoinj/bitcoinj/issues/1173, which is not considered urgent.
