### PR TITLE
Update Debian package URL's

### DIFF
--- a/contrib/debian/bitcoin-tx.lintian-overrides
+++ b/contrib/debian/bitcoin-tx.lintian-overrides
@@ -1,0 +1,2 @@
+# Linked code is Expat - only Debian packaging is GPL-2+
+bitcoin-tx: possible-gpl-code-linked-with-openssl

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,3 +1,9 @@
+bitcoinclassic (0.12.0-precise1) precise; urgency=medium
+
+  * Bitcoin Classic.
+
+ -- Jon Rumion (yamamushi) <yamamushi@gmail.com>  Thu, 3 Mar 2016 21:36:36 -0600
+
 bitcoin (0.11.0-precise1) precise; urgency=medium
 
   * New upstream release.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,8 +1,8 @@
 Source: bitcoin
 Section: utils
 Priority: optional
-Maintainer: Jonas Smedegaard <dr@jones.dk>
-Uploaders: Micah Anderson <micah@debian.org>
+Maintainer: The Classic Devs <packages@bitcoinclassic.com>
+Uploaders: Micah Anderson <micah@debian.org>, Jon Rumion <yamamushi@gmail.com>
 Build-Depends: debhelper,
  devscripts,
  automake,
@@ -23,9 +23,9 @@ Build-Depends: debhelper,
  libprotobuf-dev, protobuf-compiler,
  python
 Standards-Version: 3.9.2
-Homepage: https://bitcoincore.org/
-Vcs-Git: git://github.com/bitcoin/bitcoin.git
-Vcs-Browser: https://github.com/bitcoin/bitcoin
+Homepage: https://bitcoinclassic.com/
+Vcs-Git: git://github.com/bitcoinclassic/bitcoinclassic.git
+Vcs-Browser: https://github.com/bitcoinclassic/bitcoinclassic
 
 Package: bitcoind
 Architecture: any

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,4 +1,4 @@
-Source: bitcoin
+Source: bitcoinclassic
 Section: utils
 Priority: optional
 Maintainer: The Classic Devs <packages@bitcoinclassic.com>

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,8 +1,8 @@
-Source: bitcoin
+Source: bitcoinclassic
 Section: utils
 Priority: optional
-Maintainer: Jonas Smedegaard <dr@jones.dk>
-Uploaders: Micah Anderson <micah@debian.org>
+Maintainer: The Classic Devs <packages@bitcoinclassic.com>
+Uploaders: Micah Anderson <micah@debian.org>, Jon Rumion <yamamushi@gmail.com>
 Build-Depends: debhelper,
  devscripts,
  automake,
@@ -21,11 +21,12 @@ Build-Depends: debhelper,
  libqt4-dev,
  libqrencode-dev,
  libprotobuf-dev, protobuf-compiler,
- python
+ python,
+ libevent-dev
 Standards-Version: 3.9.2
-Homepage: https://bitcoincore.org/
-Vcs-Git: git://github.com/bitcoin/bitcoin.git
-Vcs-Browser: https://github.com/bitcoin/bitcoin
+Homepage: https://bitcoinclassic.com/
+Vcs-Git: git://github.com/bitcoinclassic/bitcoinclassic.git
+Vcs-Browser: https://github.com/bitcoinclassic/bitcoinclassic
 
 Package: bitcoind
 Architecture: any


### PR DESCRIPTION
This change is to update the VCS URL's within the Debian build, and to update the package maintainers.

These changes are necessary for pushing the Bitcoin Classic source package into Launchpad for use in a PPA. 
