### PR TITLE
Add Full-RBF for increased miner profitability.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -105,6 +105,9 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
+        // RBF-specific seed
+        vSeeds.push_back(CDNSSeedData("btc.petertodd.org", "rbf-seed.btc.petertodd.org"));
+
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me")); // Matt Corallo
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
@@ -189,6 +192,10 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
+
+        // RBF-specific seed
+        vSeeds.push_back(CDNSSeedData("tbtc.petertodd.org", "rbf-seed.tbtc.petertodd.org"));
+
         vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
         vSeeds.push_back(CDNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -863,33 +863,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             const CTransaction *ptxConflicting = pool.mapNextTx[txin.prevout].ptx;
             if (!setConflicts.count(ptxConflicting->GetHash()))
             {
-                // Allow opt-out of transaction replacement by setting
-                // nSequence >= maxint-1 on all inputs.
-                //
-                // maxint-1 is picked to still allow use of nLockTime by
-                // non-replacable transactions. All inputs rather than just one
-                // is for the sake of multi-party protocols, where we don't
-                // want a single party to be able to disable replacement.
-                //
-                // The opt-out ignores descendants as anyone relying on
-                // first-seen mempool behavior should be checking all
-                // unconfirmed ancestors anyway; doing otherwise is hopelessly
-                // insecure.
-                bool fReplacementOptOut = true;
-                if (fEnableReplacement)
-                {
-                    BOOST_FOREACH(const CTxIn &txin, ptxConflicting->vin)
-                    {
-                        if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1)
-                        {
-                            fReplacementOptOut = false;
-                            break;
-                        }
-                    }
-                }
-                if (fReplacementOptOut)
-                    return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
-
                 setConflicts.insert(ptxConflicting->GetHash());
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4373,6 +4373,25 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
+        // Disconnect if we have already met our quota of non-doublespend-relaying nodes.
+        if (!(pfrom->nServices & NODE_RELAYS_DOUBLESPENDS))
+        {
+            int nNonDoubleSpendRelaying = 0;
+
+            LOCK(cs_vNodes);
+            BOOST_FOREACH(CNode* pnode, vNodes) {
+                if (!(pnode->nServices & NODE_RELAYS_DOUBLESPENDS))
+                    nNonDoubleSpendRelaying++;
+            }
+
+            if (nNonDoubleSpendRelaying > nMaxConnections / 4) {
+                LogPrint("net", "reached quota of non-doublespend-relaying nodes; disconnecting %s\n",
+                         pfrom->addr.ToString());
+                pfrom->fDisconnect = true;
+                return false;
+            }
+        }
+
         if (pfrom->nVersion == 10300)
             pfrom->nVersion = 300;
         if (!vRecv.empty())

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -74,7 +74,7 @@ namespace {
 //
 bool fDiscover = true;
 bool fListen = true;
-uint64_t nLocalServices = NODE_NETWORK;
+uint64_t nLocalServices = NODE_NETWORK | NODE_REPLACE_BY_FEE;
 CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1615,7 +1615,7 @@ void ThreadOpenConnections()
             // find out afterwords that what we thought was a node's nServices
             // was incorrect; Bitcoin Core will even stay connected to nodes
             // not advertising NODE_NETWORK in this case.
-            if (!((addr.nServices & NODE_RELAYS_DOUBLESPENDS) && (addr.nServices & ~NODE_RELAYS_DOUBLESPENDS) == NODE_NETWORK)
+            if (!((addr.nServices & ~NODE_BLOOM) == (NODE_NETWORK | NODE_RELAYS_DOUBLESPENDS))
                     && (nOutbound - nDoubleSpendRelayingOutbound >= MAX_STD_OUTBOUND_CONNECTIONS))
                 continue;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -59,7 +59,10 @@
 using namespace std;
 
 namespace {
-    const int MAX_OUTBOUND_CONNECTIONS = 8;
+    const int MAX_STD_OUTBOUND_CONNECTIONS = 8;
+    const int MIN_REPLACE_BY_FEE_OUTBOUND_CONNECTIONS = 8;
+
+    const int MAX_OUTBOUND_CONNECTIONS = MAX_STD_OUTBOUND_CONNECTIONS + MIN_REPLACE_BY_FEE_OUTBOUND_CONNECTIONS;
 
     struct ListenSocket {
         SOCKET socket;
@@ -1557,6 +1560,7 @@ void ThreadOpenConnections()
         // Only connect out to one peer per network group (/16 for IPv4).
         // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
         int nOutbound = 0;
+        int nDoubleSpendRelayingOutbound = 0;
         set<vector<unsigned char> > setConnected;
         {
             LOCK(cs_vNodes);
@@ -1564,6 +1568,9 @@ void ThreadOpenConnections()
                 if (!pnode->fInbound) {
                     setConnected.insert(pnode->addr.GetGroup());
                     nOutbound++;
+
+                    if (pnode->nServices & NODE_RELAYS_DOUBLESPENDS)
+                        nDoubleSpendRelayingOutbound++;
                 }
             }
         }
@@ -1595,6 +1602,21 @@ void ThreadOpenConnections()
 
             // do not allow non-default ports, unless after 50 invalid addresses selected already
             if (addr.GetPort() != Params().GetDefaultPort() && nTries < 50)
+                continue;
+
+            // Reserve some outbound connections for nodes that relay
+            // double-spends.
+            //
+            // Unfortunately nServices seems to end up corrupted at times,
+            // leading us to adding more nodes than expected, so this is a more
+            // strict test than might otherwise be expected.
+            //
+            // Also, we'll still end up with too many at times, because we'll
+            // find out afterwords that what we thought was a node's nServices
+            // was incorrect; Bitcoin Core will even stay connected to nodes
+            // not advertising NODE_NETWORK in this case.
+            if (!((addr.nServices & NODE_RELAYS_DOUBLESPENDS) && (addr.nServices & ~NODE_RELAYS_DOUBLESPENDS) == NODE_NETWORK)
+                    && (nOutbound - nDoubleSpendRelayingOutbound >= MAX_STD_OUTBOUND_CONNECTIONS))
                 continue;
 
             addrConnect = addr;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -246,6 +246,8 @@ enum {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
+    NODE_REPLACE_BY_FEE = (1 << 26),
 };
 
 /** A CService with information about it as peer */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -230,6 +230,7 @@ enum {
     // set by all Bitcoin Classic nodes, and is unset by SPV clients or other peers that just want
     // network services but don't provide them.
     NODE_NETWORK = (1 << 0),
+
     // NODE_GETUTXO means the node is capable of responding to the getutxo protocol request.
     // Bitcoin Classic does not support this but a patch set called Bitcoin XT does.
     // See BIP 64 for details on how this is implemented.
@@ -249,6 +250,8 @@ enum {
 
     NODE_REPLACE_BY_FEE = (1 << 26),
 };
+
+const uint64_t NODE_RELAYS_DOUBLESPENDS = NODE_REPLACE_BY_FEE;
 
 /** A CService with information about it as peer */
 class CAddress : public CService


### PR DESCRIPTION
Some miners are not able to stay online right now due to increased competition and need higher fees in order to stay operational. We should merge this patch-set to give them an economic incentive to switch to Classic. We may want to give the miner a config flag in order to choose their mempool policy if this is accepted. Removed merge commits per @zander's [request](https://github.com/bitcoinclassic/bitcoinclassic/pull/136#issuecomment-193685611).
