### PR TITLE
Extend checkpointing to 24 hours in the past.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1834,14 +1834,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return true;
     }
 
-    bool fScriptChecks = true;
-    if (fCheckpointsEnabled) {
-        CBlockIndex *pindexLastCheckpoint = Checkpoints::GetLastCheckpoint(chainparams.Checkpoints());
-        if (pindexLastCheckpoint && pindexLastCheckpoint->GetAncestor(pindex->nHeight) == pindex) {
-            // This block is an ancestor of a checkpoint: disable script checks
-            fScriptChecks = false;
-        }
-    }
+    const int64_t timeBarrier = GetTime() - 24 * 3600 * std::max(1, nScriptCheckThreads);
+    // Blocks that have varius days of POW behind them makes them secure in
+    // that actually online nodes checked the scripts, so during initial sync we
+    // don't need to check the scripts.
+    // All other block validity tests are still checked.
+    bool fScriptChecks = !fCheckpointsEnabled || block.nTime > timeBarrier;
 
     int64_t nTime1 = GetTimeMicros(); nTimeCheck += nTime1 - nTimeStart;
     LogPrint("bench", "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);


### PR DESCRIPTION
Checkpoints are hardcoded points that are shipped in the client and we
skip checking of script validity if they come before a checkpoint.
This change builds on that and extends the no-check requirement from
known good points to proven-good points.
A chain with more than 24 hours work on it has proven to be correct
and we can skip the checking of scripts.
