### PR TITLE
Change MAX_PROTOCOL_MESSAGE_LENGTH from 2MiB to 4MiB

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -43,8 +43,8 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
+/** Maximum length of incoming protocol messages (no message over 4 MiB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** -listen default */


### PR DESCRIPTION
MAX_PROTOCOL_MESSAGE_LENGTH is set to 2MiB in Bitcoin Core. In Classic, if a 2MB block is sent by Block message, it may be rejected by CNode::ReceiveMsgBytes(). So I increase it to 4MiB.
