### PR TITLE
Head first mining

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -107,6 +107,7 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py',
+    'headfirstmining.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/rpc-tests/headfirstmining.py
+++ b/qa/rpc-tests/headfirstmining.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+import binascii
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
+
+'''
+HeadFirstMining.py
+
+Test some unlikely scenarios involving valid-proof-of-work
+but invalid-something-else full blocks.
+
+'''
+
+class BaseNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.last_inv = None
+        self.last_headers = None
+        self.last_block = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong(0)
+        self.last_getdata = None
+        self.sleep_time = 0.05
+        self.block_announced = False
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_inv(self, conn, message):
+        self.last_inv = message
+        self.block_announced = True
+
+    def on_headers(self, conn, message):
+        self.last_headers = message
+        self.block_announced = True
+
+    def on_block(self, conn, message):
+        self.last_block = message.block
+        self.last_block.calc_sha256()
+
+    def on_getdata(self, conn, message):
+        self.last_getdata = message
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Syncing helpers
+    def sync(self, test_function, timeout=60):
+        while timeout > 0:
+            with mininode_lock:
+                if test_function():
+                    return
+            time.sleep(self.sleep_time)
+            timeout -= self.sleep_time
+        raise AssertionError("Sync failed to complete")
+        
+    def sync_with_ping(self, timeout=60):
+        self.send_message(msg_ping(nonce=self.ping_counter))
+        test_function = lambda: self.last_pong.nonce == self.ping_counter
+        self.sync(test_function, timeout)
+        self.ping_counter += 1
+        return
+
+    def wait_for_block(self, blockhash, timeout=60):
+        test_function = lambda: self.last_block != None and self.last_block.sha256 == blockhash
+        self.sync(test_function, timeout)
+        return
+
+    def wait_for_getdata(self, hash_list, timeout=60):
+        if hash_list == []:
+            return
+
+        test_function = lambda: self.last_getdata != None and [x.hash for x in self.last_getdata.inv] == hash_list
+        self.sync(test_function, timeout)
+        return
+
+    def send_header_for_blocks(self, new_blocks):
+        headers_message = msg_headers()
+        headers_message.headers = [ CBlockHeader(b) for b in new_blocks ]
+        self.send_message(headers_message)
+
+# TestNode: This peer is the one we use for most of the testing.
+class TestNode(BaseNode):
+    def __init__(self):
+        BaseNode.__init__(self)
+
+class HeadFirstMineTest(BitcoinTestFramework):
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes = start_nodes(4, self.options.tmpdir, [["-debug=net", "-banscore=999999", "-logtimemicros=1"]]*4)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[2], 3) # 0 -> 1 -> 2 -> 3 connected in a chain
+
+    def create_valid_block(self, tip):
+        height = self.nodes[0].getblockcount()
+        block_time = max(int(time.time()), self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']+1)
+        new_block = create_block(tip, create_coinbase(height+1), block_time)
+        new_block.solve()
+        return new_block
+
+    def create_invalid_block(self, tip):
+        height = self.nodes[0].getblockcount()
+        block_time = max(int(time.time()), self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']+1)
+        new_block = create_block(tip, create_coinbase(height+1), block_time)
+        new_block.vtx.append(create_transaction(new_block.vtx[0], 0, chr(81), 50))
+        new_block.hashMerkleRoot = new_block.calc_merkle_root()
+        new_block.rehash()
+        new_block.solve()
+        return new_block
+
+    def wait_for(self, test_function, wait=1, timeout=30):
+        while not test_function():
+            time.sleep(wait)
+            timeout -= wait;
+            if timeout < 0:
+                raise AssertionError("Unexpected wait_for timeout")
+
+    def run_test(self):
+        # Setup the p2p connections and start up the network thread.
+        test_node = TestNode()
+
+        self.p2p_connections = [test_node]
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node))
+        test_node.add_connection(connections[0])
+
+        NetworkThread().start() # Start up network handling in another thread
+
+        test_node.wait_for_verack()
+        test_node.send_message(msg_sendheaders())
+
+        # Network initialized, ready to start testing.
+
+        # test_node.send_header_for_blocks is used to send headers first,
+        # and behavior is tested before and after the full block is sent
+        # with .send_message(msg_block)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes) # make sure all the nodes are out of initial-download state
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+
+        # 1. Create a block, send header to peer,
+        #    it should mine on that header
+        new_block = self.create_valid_block(tip)
+        test_node.send_header_for_blocks([new_block])
+        test_node.wait_for_getdata([new_block.sha256], timeout=5)
+        block_template = self.nodes[0].getblocktemplate()
+        assert_equal(new_block.sha256, int(block_template['previousblockhash'], 16))
+
+        # 2. If node[0] generates a new block, should build on that:
+        new_tip = int(self.nodes[0].generate(1)[0], 16)
+        block_template = self.nodes[0].getblocktemplate()
+        assert_equal(new_tip, int(block_template['previousblockhash'], 16))
+
+        test_node.send_message(msg_block(new_block))
+        self.wait_for(lambda: int(self.nodes[3].getblocktemplate()['previousblockhash'], 16) == new_tip)
+
+        tip = new_tip
+
+        # 3. Create a block with valid POW but containing an invalid transaction
+        new_block = self.create_invalid_block(tip)
+        test_node.send_header_for_blocks([new_block])
+        test_node.wait_for_getdata([new_block.sha256], timeout=5)
+        block_template = self.nodes[0].getblocktemplate()
+        assert_equal(new_block.sha256, int(block_template['previousblockhash'], 16)) # Should build on the invalid block
+        
+        # ... once full invalid block received: shouldn't build on it:
+        test_node.send_message(msg_block(new_block))
+        test_node.sync_with_ping()
+        block_template = self.nodes[0].getblocktemplate()
+        assert_equal(tip, int(block_template['previousblockhash'], 16))
+
+        # 4. Test submitblock when mining on top of header:
+        invalid_parent = self.create_invalid_block(tip)
+        test_node.send_header_for_blocks([invalid_parent])
+        test_node.wait_for_getdata([invalid_parent.sha256], timeout=5)
+        valid_child = self.create_valid_block(invalid_parent.sha256)
+        data = valid_child.serialize()
+        result = self.nodes[0].submitblock(binascii.hexlify(data))
+        block_template = self.nodes[0].getblocktemplate()
+        # Mining on valid_child:
+        assert_equal(valid_child.sha256, int(block_template['previousblockhash'], 16))
+        # .. but best block is still tip:
+        assert_equal(tip, int(self.nodes[0].getbestblockhash(), 16))
+
+        # 5. Invalid parent validated: switch to mining on tip
+        test_node.send_message(msg_block(invalid_parent))
+        test_node.sync_with_ping()
+        block_template = self.nodes[0].getblocktemplate()
+        assert_equal(tip, int(block_template['previousblockhash'], 16))
+
+if __name__ == '__main__':
+    HeadFirstMineTest().main()

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -37,13 +37,15 @@ def serialize_script_num(value):
         r[-1] |= 0x80
     return r
 
-# Create a coinbase transaction, assuming no miner fees.
+# Create a unique coinbase transaction, assuming no miner fees.
 # If pubkey is passed in, the coinbase output will be a P2PK output;
 # otherwise an anyone-can-spend output.
 def create_coinbase(height, pubkey = None):
+    if not hasattr(create_coinbase, "counter"): create_coinbase.counter = 0
+    else: create_coinbase.counter += 1
     coinbase = CTransaction()
     coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
-                ser_string(serialize_script_num(height)), 0xffffffff))
+                ser_string(serialize_script_num(height)+serialize_script_num(create_coinbase.counter)), 0xffffffff))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50*100000000
     halvings = int(height/150) # regtest

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -823,6 +823,25 @@ class msg_block(object):
         return "msg_block(block=%s)" % (repr(self.block))
 
 
+class msg_invalidblock(object):
+    command = "invalidblock"
+
+    def __init__(self, block=None):
+        if block is None:
+            self.block = CBlock()
+        else:
+            self.block = block
+
+    def deserialize(self, f):
+        self.block.deserialize(f)
+
+    def serialize(self):
+        return self.block.serialize()
+
+    def __repr__(self):
+        return "msg_invalidblock(block=%s)" % (repr(self.block))
+
+
 class msg_getaddr(object):
     command = "getaddr"
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -50,6 +50,10 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
     return CBlockLocator(vHave);
 }
 
+// Putting first seen time in a map instead of making it a member
+// of CBlockIndex is a memory optimization
+std::map<const CBlockIndex*, int64_t> CBlockIndex::firstSeenTime;
+
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     if (pindex == NULL) {
         return NULL;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -325,6 +325,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-alerts", strprintf(_("Receive and display P2P network alerts (default: %u)"), DEFAULT_ALERTS));
     strUsage += HelpMessageOpt("-alertnotify=<cmd>", _("Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)"));
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash)"));
+    strUsage += HelpMessageOpt("-blockheadernotify=<cmd>", _("Execute command when the best block header changes (%s in cmd is replaced by block hash)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
@@ -535,6 +536,17 @@ std::string LicenseInfo()
            "\n" +
            FormatParagraph(_("This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit <https://www.openssl.org/> and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.")) +
            "\n";
+}
+
+static void BlockHeaderNotifyCallback(const CBlockIndex *pBlockIndex)
+{
+    if (!pBlockIndex)
+        return;
+
+    std::string strCmd = GetArg("-blockheadernotify", "");
+
+    boost::replace_all(strCmd, "%s", pBlockIndex->GetBlockHash().GetHex());
+    boost::thread t(runCommand, strCmd); // thread runs free
 }
 
 static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex)
@@ -1604,6 +1616,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (mapArgs.count("-blocknotify"))
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
+    if (mapArgs.count("-blockheadernotify"))
+        uiInterface.NotifyBlockHeader.connect(BlockHeaderNotifyCallback);
 
     uiInterface.InitMessage(_("Activating best chain..."));
     // scan for better chains in the block chain database, that are not yet connected in the active best chain

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -250,6 +250,12 @@ void Shutdown()
     delete pwalletMain;
     pwalletMain = NULL;
 #endif
+    // block headers
+    BlockMap::iterator it1 = mapBlockIndex.begin();
+    for (; it1 != mapBlockIndex.end(); it1++)
+        delete (*it1).second;
+    mapBlockIndex.clear();
+
     globalVerifyHandle.reset();
     ECC_Stop();
     LogPrintf("%s: done\n", __func__);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4711,6 +4711,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         CBlockIndex *pindexLast = NULL;
+        CBlockIndex *pindexLastBestHeader = pindexBestHeader;
         BOOST_FOREACH(const CBlockHeader& header, headers) {
             CValidationState state;
             if (pindexLast != NULL && header.hashPrevBlock != pindexLast->GetBlockHash()) {
@@ -4729,6 +4730,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (pindexLast)
             UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
+
+        if (pindexBestHeader && pindexBestHeader != pindexLastBestHeader) {
+            cvBlockChange.notify_all();
+            uiInterface.NotifyBlockHeader(pindexBestHeader);
+        }
 
         if (nCount == MAX_HEADERS_RESULTS && pindexLast) {
             // Headers message had its maximum size; the peer may have more headers.

--- a/src/main.h
+++ b/src/main.h
@@ -453,7 +453,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = t
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex *pindexPrev);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex *pindexPrev);
 
-/** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
+/**
+ * Check if a block is valid. Checking proof-of-work and merkle root may be skipped,
+ * as will testing against the current unspent transactions if pindexPrev is not
+ * our current best block.
+ * Returns false if block is not valid, with details on why validation failed returned in state.
+ * Requires cs_main to be held. */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -72,7 +72,8 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 }
 
 
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn)
+CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn,
+                               CBlockIndex* pindexPrev, CTxMemPool& mPool)
 {
     // Create new block
     auto_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
@@ -114,8 +115,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     bool fCreatedValidBlock = false;
 
     {
-        LOCK2(cs_main, mempool.cs);
-        CBlockIndex* pindexPrev = chainActive.Tip();
+        LOCK2(cs_main, mPool.cs);
         const int nHeight = pindexPrev->nHeight + 1;
         pblock->nTime = GetAdjustedTime();
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
@@ -157,23 +157,23 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 
         bool fPriorityBlock = nBlockPrioritySize > 0;
         if (fPriorityBlock) {
-            vecPriority.reserve(mempool.mapTx.size());
-            for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin();
-                 mi != mempool.mapTx.end(); ++mi)
+            vecPriority.reserve(mPool.mapTx.size());
+            for (CTxMemPool::indexed_transaction_set::iterator mi = mPool.mapTx.begin();
+                 mi != mPool.mapTx.end(); ++mi)
             {
                 double dPriority = mi->GetPriority(nHeight);
                 CAmount dummy;
-                mempool.ApplyDeltas(mi->GetTx().GetHash(), dPriority, dummy);
+                mPool.ApplyDeltas(mi->GetTx().GetHash(), dPriority, dummy);
                 vecPriority.push_back(TxCoinAgePriority(dPriority, mi));
             }
             std::make_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
         }
 
-        CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
+        CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mPool.mapTx.get<3>().begin();
         CTxMemPool::txiter iter;
         uint32_t nMaxLegacySigops = MaxLegacySigops(pblock->nTime);
 
-        while (mi != mempool.mapTx.get<3>().end() || !clearedTxs.empty())
+        while (mi != mPool.mapTx.get<3>().end() || !clearedTxs.empty())
         {
             bool priorityTx = false;
             if (fPriorityBlock && !vecPriority.empty()) { // add a tx from priority queue to fill the blockprioritysize
@@ -184,7 +184,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
                 vecPriority.pop_back();
             }
             else if (clearedTxs.empty()) { // add tx with next highest score
-                iter = mempool.mapTx.project<0>(mi);
+                iter = mPool.mapTx.project<0>(mi);
                 mi++;
             }
             else {  // try to add a previously postponed child tx
@@ -198,7 +198,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             const CTransaction& tx = iter->GetTx();
 
             bool fOrphan = false;
-            BOOST_FOREACH(CTxMemPool::txiter parent, mempool.GetMemPoolParents(iter))
+            BOOST_FOREACH(CTxMemPool::txiter parent, mPool.GetMemPoolParents(iter))
             {
                 if (!inBlock.count(parent)) {
                     fOrphan = true;
@@ -260,7 +260,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             {
                 double dPriority = iter->GetPriority(nHeight);
                 CAmount dummy;
-                mempool.ApplyDeltas(tx.GetHash(), dPriority, dummy);
+                mPool.ApplyDeltas(tx.GetHash(), dPriority, dummy);
                 LogPrintf("priority %.1f fee %s txid %s\n",
                           dPriority , CFeeRate(iter->GetModifiedFee(), nTxSize).ToString(), tx.GetHash().ToString());
             }
@@ -268,7 +268,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             inBlock.insert(iter);
 
             // Add transactions that depend on this one to the priority queue
-            BOOST_FOREACH(CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+            BOOST_FOREACH(CTxMemPool::txiter child, mPool.GetMemPoolChildren(iter))
             {
                 if (fPriorityBlock) {
                     waitPriIter wpiter = waitPriMap.find(child);
@@ -326,7 +326,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 
     if (!fCreatedValidBlock) {
         pblocktemplate.reset();
-        return CreateNewBlock(chainparams, scriptPubKeyIn); // recurse with smaller mempool
+        return CreateNewBlock(chainparams, scriptPubKeyIn, pindexPrev, mPool); // recurse with smaller mempool
     }
 
     return pblocktemplate.release();
@@ -452,7 +452,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
             unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
 
-            auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(chainparams, coinbaseScript->reserveScript));
+            auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(chainparams, coinbaseScript->reserveScript, pindexPrev, mempool));
             if (!pblocktemplate.get())
             {
                 LogPrintf("Error in BitcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n");

--- a/src/miner.h
+++ b/src/miner.h
@@ -14,6 +14,7 @@ class CBlockIndex;
 class CChainParams;
 class CReserveKey;
 class CScript;
+class CTxMemPool;
 class CWallet;
 namespace Consensus { struct Params; };
 
@@ -32,7 +33,7 @@ struct CBlockTemplate
 /** Run the miner threads */
 void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainparams);
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn);
+CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn, CBlockIndex* pindexPrev, CTxMemPool& mPool);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/net.h
+++ b/src/net.h
@@ -325,6 +325,7 @@ public:
     CCriticalSection cs_vSend;
 
     std::deque<CInv> vRecvGetData;
+    std::map<uint256, int> waitingForBlock; // peer is waiting for data for these blocks
     std::deque<CNetMessage> vRecvMsg;
     CCriticalSection cs_vRecvMsg;
     uint64_t nRecvBytes;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -35,6 +35,7 @@ const char *FILTERADD="filteradd";
 const char *FILTERCLEAR="filterclear";
 const char *REJECT="reject";
 const char *SENDHEADERS="sendheaders";
+const char *INVALIDBLOCK="invalidblock";
 };
 
 static const char* ppszTypeName[] =
@@ -70,7 +71,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::FILTERADD,
     NetMsgType::FILTERCLEAR,
     NetMsgType::REJECT,
-    NetMsgType::SENDHEADERS
+    NetMsgType::SENDHEADERS,
+    NetMsgType::INVALIDBLOCK
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -218,6 +218,11 @@ extern const char *REJECT;
  * @see https://bitcoin.org/en/developer-reference#sendheaders
  */
 extern const char *SENDHEADERS;
+/**
+ * The invalidblock message transmits a single serialized block that
+ * has valid proof-of-work but was found to be invalid for some reason.
+ */
+extern const char *INVALIDBLOCK;
 
 };
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -157,7 +157,7 @@ UniValue generate(const UniValue& params, bool fHelp)
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(Params(), coinbaseScript->reserveScript));
+        auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(Params(), coinbaseScript->reserveScript, chainActive.Tip(), mempool));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
@@ -511,7 +511,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             pblocktemplate = NULL;
         }
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = CreateNewBlock(Params(), scriptDummy);
+        pblocktemplate = CreateNewBlock(Params(), scriptDummy, chainActive.Tip(), mempool);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -442,6 +442,13 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
 
     static unsigned int nTransactionsUpdatedLast;
+    static CTxMemPool emptyMemPool(CFeeRate(0));
+
+    // Which tip to build on
+    CBlockIndex* build_tip = chainActive.Tip();
+
+    // Memory pool to get transactions from
+    CTxMemPool* mPool = (build_tip == chainActive.Tip() ? &mempool : &emptyMemPool);
 
     if (!lpval.isNull())
     {
@@ -461,7 +468,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         else
         {
             // NOTE: Spec does not specify behaviour for non-string longpollid, but this makes testing easier
-            hashWatchedChain = chainActive.Tip()->GetBlockHash();
+            hashWatchedChain = build_tip->GetBlockHash();
             nTransactionsUpdatedLastLP = nTransactionsUpdatedLast;
         }
 
@@ -471,15 +478,16 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             checktxtime = boost::get_system_time() + boost::posix_time::minutes(1);
 
             boost::unique_lock<boost::mutex> lock(csBestBlock);
-            while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
+            while (build_tip->GetBlockHash() == hashWatchedChain && IsRPCRunning())
             {
                 if (!cvBlockChange.timed_wait(lock, checktxtime))
                 {
                     // Timeout: Check transactions for update
-                    if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
+                    if (mPool->GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
                         break;
                     checktxtime += boost::posix_time::seconds(10);
                 }
+                build_tip = chainActive.Tip();
             }
         }
         ENTER_CRITICAL_SECTION(cs_main);
@@ -493,15 +501,16 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static CBlockTemplate* pblocktemplate;
-    if (pindexPrev != chainActive.Tip() ||
-        (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+
+    if (pindexPrev != build_tip ||
+        (mPool->GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = NULL;
 
         // Store the pindexBest used before CreateNewBlock, to avoid races
-        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-        CBlockIndex* pindexPrevNew = chainActive.Tip();
+        nTransactionsUpdatedLast = mPool->GetTransactionsUpdated();
+        CBlockIndex* pindexPrevNew = build_tip;
         nStart = GetTime();
 
         // Create new block
@@ -577,7 +586,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
-    result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
+    result.push_back(Pair("longpollid", build_tip->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time1)
 
     LOCK(cs_main);
 
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     CBlock *pblock = &pblocktemplate->block;
 
     // Before fork time...
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time2)
 
     LOCK(cs_main);
 
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     CBlock *pblock = &pblocktemplate->block;
 
     // Exactly at fork time...
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_NoActivation)
 
     LOCK(cs_main);
 
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     CBlock *pblock = &pblocktemplate->block;
 
     // Exactly at fork time...

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
 
     // We can't make transactions until we have inputs
     // Therefore, load 100 blocks :)
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     delete pblocktemplate;
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     delete pblocktemplate;
 
     // block sigops > limit: 1000 CHECKMULTISIG + 1
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK(!mempool.exists(hash));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1);
     delete pblocktemplate;
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOps(20).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK(pblocktemplate->block.vtx.size() > 1);
     delete pblocktemplate;
     mempool.clear();
@@ -163,14 +163,14 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     delete pblocktemplate;
     mempool.clear();
 
     // orphan in mempool not mined
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1);
     delete pblocktemplate;
     mempool.clear();
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = 5900000000LL;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(400000000LL).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     delete pblocktemplate;
     mempool.clear();
 
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     // give it a fee so it'll get mined
     mempool.addUnchecked(hash, entry.Fee(100000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1);
     delete pblocktemplate;
     mempool.clear();
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue -= 1000000;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1); // Just coinbase
     mempool.clear();
 
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1); // Just coinbase
     delete pblocktemplate;
     mempool.clear();
@@ -242,10 +242,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // subsidy changing
     int nHeight = chainActive.Height();
     chainActive.Tip()->nHeight = 209999;
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     delete pblocktemplate;
     chainActive.Tip()->nHeight = 210000;
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     delete pblocktemplate;
     chainActive.Tip()->nHeight = nHeight;
 
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbase(true).FromTx(tx2));
     BOOST_CHECK(!CheckFinalTx(tx2, LOCKTIME_MEDIAN_TIME_PAST));
 
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
 
     // Neither tx should have make it into the template.
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1);
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     //BOOST_CHECK(CheckFinalTx(tx));
     //BOOST_CHECK(CheckFinalTx(tx2));
 
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 2);
     delete pblocktemplate;
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -117,7 +117,7 @@ CBlock
 TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    CBlockTemplate *pblocktemplate = CreateNewBlock(chainparams, scriptPubKey);
+    CBlockTemplate *pblocktemplate = CreateNewBlock(chainparams, scriptPubKey, chainActive.Tip(), mempool);
     CBlock& block = pblocktemplate->block;
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -94,6 +94,9 @@ public:
     /** Show progress e.g. for verifychain */
     boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
 
+    /** New block header has been accepted */
+    boost::signals2::signal<void (const CBlockIndex *)> NotifyBlockHeader;
+
     /** New block has been accepted */
     boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyBlockTip;
 


### PR DESCRIPTION
Implement "head first mining" : propagate new 80-byte block headers as quickly as possible across the network, and give miners the opportunity to start mining an empty block as soon as they hear about the block header.

Only valid proof-of-work headers that connect to the most-work chain are relayed, so there are no feasible denial-of-service attacks.

Miners will switch to mining a regular block as soon as the full block is received and validated.

There is a hard-coded 30-second timeout; if the full block data takes longer than 30 seconds to get validated and propagated across the network, or is never sent, miners switch back to mining non-empty blocks on the last fully-validated block.

Details:

New getblocktemplate behavior:  getblocktemplate returns an empty (just coinbase transaction) block template in the time between receiving a new block's 'headers' message and receiving and validating the 'block' message. Long-polling getblocktemplate connections are interrupted when a new best-header is received and when blocks are fully validated.

New command-line option, -blockheadernotify. Just like -blocknotify, but notified when a new most-work-header is received.

New p2p message, 'invalidblock'.  Just like the 'block' message, but sent to peers when an invalid block that has valid proof-of-work is received, to tell them they should stop mining on the block's header. 

Only peers that follow the BIP130 'sendheaders' protocol will be relayed headers immediately, and only they will receive 'invalidblock' messages.  SPV clients don't 'sendheaders', so should be unaffected. Older clients that don't understand the 'invalidblock' message will ignore it.

---

Please limit discussion here on github to code review and testing results. Debate on whether or not head-first mining is a benefit to the network should happen in the bitcoin-classic #debate slack channel and/or the #bitcoin-dev IRC channel.
