### PR TITLE
Update build-linux.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -73,10 +73,10 @@ If that doesn't work, you can install all boost development packages with:
 
     sudo apt-get install libboost-all-dev
 
-BerkeleyDB is required for the wallet. db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
+BerkeleyDB is required for the wallet. db4.8 packages are available [here](https://launchpad.net/~bitcoinclassic/+archive/bitcoinclassic).
 You can add the repository and install using the following commands:
 
-    sudo add-apt-repository ppa:bitcoin/bitcoin
+    sudo add-apt-repository ppa:bitcoinclassic/bitcoinclassic
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev
 


### PR DESCRIPTION
Fixed the PPA instructions. The BitcoinClassic PPA has the BDB 4.8 necessary to build, and this way people don't add the Bitcoin Core PPA which could lead to them somehow installing Bitcoin Core by accident.
