### PR TITLE
Implement loading/saving of Transactionv4

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -110,6 +110,7 @@ testScripts = [
     'abandonconflict.py',
     'p2p-versionbits-warning.py',
     'bip68-sequence.py',
+    'transactionv4.py',
 ]
 testScriptsExt = [
     'bip9-softforks.py',

--- a/qa/rpc-tests/transactionv4.py
+++ b/qa/rpc-tests/transactionv4.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python2
+# Copyright (c) 2016 Tom Zander <tomz@freedommail.ch>
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test creation of a v4 transaction, mining it and forwarding it to other nodes.
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class Transactionv4(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug"]))
+        connect_nodes(self.nodes[0], 1)
+
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        print "Mining blocks..."
+        self.nodes[0].wallet.generate(105)
+        self.sync_all()
+
+        # chain_height = self.nodes[1].getblockcount()
+
+        node0utxos = self.nodes[0].listunspent(1)
+        print "Creating v4 tx..."
+        tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 50}, 0, 4)
+        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
+        self.sync_all()
+        print "Checking for propagation"
+        self.nodes[1].wallet.generate(1)
+        self.sync_all()
+        block = self.nodes[0].getblock(self.nodes[0].getbestblockhash())
+        assert_equal(block["height"], 106)
+        tx_list = block["tx"]
+        assert_equal(len(tx_list), 2)
+        assert_equal(tx_list[1], txid1)
+
+if __name__ == '__main__':
+    Transactionv4().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,6 +96,7 @@ BITCOIN_CORE_H = \
   consensus/merkle.h \
   consensus/params.h \
   consensus/validation.h \
+  consensus/transactionv4.h \
   core_io.h \
   core_memusage.h \
   hash.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -82,6 +82,8 @@ BITCOIN_TESTS =\
   test/thinblock_tests.cpp \
   test/timedata_tests.cpp \
   test/transaction_tests.cpp \
+  test/transaction_utils.cpp \
+  test/transaction_utils.h \
   test/txvalidationcache_tests.cpp \
   test/versionbits_tests.cpp \
   test/uint256_tests.cpp \

--- a/src/consensus/transactionv4.h
+++ b/src/consensus/transactionv4.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef TRANSACTION_4_H
+#define TRANSACTION_4_H
+
+namespace Consensus {
+enum TxMessageFields {
+    TxEnd = 0,          // BoolTrue
+    TxInPrevHash,       // sha256 (Bytearray)
+    TxInPrevIndex,      // PositiveNumber
+    TxInPrevHeight,     // PositiveNumber
+    TxInScript,         // bytearray
+    TxOutValue,         // PositiveNumber (in satoshis)
+    TxOutScript,        // bytearray
+    LockByBlock,        // PositiveNumber
+    LockByTime,         // PositiveNumber
+    ScriptVersion       // PositiveNumber
+};
+}
+
+#endif

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -77,6 +77,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createrawtransaction", 0 },
     { "createrawtransaction", 1 },
     { "createrawtransaction", 2 },
+    { "createrawtransaction", 3 },
     { "signrawtransaction", 1 },
     { "signrawtransaction", 2 },
     { "sendrawtransaction", 1 },

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -539,7 +539,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
         entry.push_back(Pair("data", EncodeHexTx(tx)));
 
-        entry.push_back(Pair("hash", txHash.GetHex()));
+        entry.push_back(Pair("txid", txHash.GetHex()));
+        entry.push_back(Pair("hash", tx.CalculateSignaturesHash().GetHex()));
 
         UniValue deps(UniValue::VARR);
         BOOST_FOREACH (const CTxIn &in, tx.vin)

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -318,9 +318,9 @@ UniValue verifytxoutproof(const UniValue& params, bool fHelp)
 
 UniValue createrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 3)
+    if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
-            "createrawtransaction [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,\"data\":\"hex\",...} ( locktime )\n"
+            "createrawtransaction [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,\"data\":\"hex\",...} ( locktime, txversion )\n"
             "\nCreate a transaction spending the given inputs and creating new outputs.\n"
             "Outputs can be addresses or data.\n"
             "Returns hex-encoded raw transaction.\n"
@@ -343,6 +343,7 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
             "      ...\n"
             "    }\n"
             "3. locktime                (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs\n"
+            "4. txversion               (numeric, optional, default=1) Specifies the transaction format version\n"
             "\nResult:\n"
             "\"transaction\"            (string) hex string of the transaction\n"
 
@@ -368,6 +369,13 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
         if (nLockTime < 0 || nLockTime > std::numeric_limits<uint32_t>::max())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, locktime out of range");
         rawTx.nLockTime = nLockTime;
+        rawTx.nVersion = 1; // use version one for the deprecated NLockTime
+    }
+    if (params.size() > 3 && !params[3].isNull()) {
+        int version = params[3].get_int();
+        if (version != 1 && version != 4)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, txversion can only be 1 or 4");
+        rawTx.nVersion = version;
     }
 
     for (unsigned int idx = 0; idx < inputs.size(); idx++) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1122,6 +1122,8 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
         }
     }
 
+    if (txTo.nVersion == 4)
+        return txTo.GetHash();
     // Wrapper to serialize only the necessary parts of the transaction being signed
     CTransactionSignatureSerializer txTmp(txTo, scriptCode, nIn, nHashType);
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -144,6 +144,16 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
+
+    // again for a v4 transaction.
+    r = CallRPC(string("createrawtransaction ")+prevout+" {\"3HqAe9LtNBjnsfM4CyYaWTnvCaUYT7v4oZ\":11}	0	4");
+    notsigned = r.get_str();
+    BOOST_CHECK(notsigned.size() > 8);
+    BOOST_CHECK_EQUAL(notsigned.substr(0, 8), "04000000"); // make sure we actually got a v4 tx
+    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[]");
+    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
+    r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
+    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_createraw_op_return)

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -12,6 +12,7 @@
 #include "serialize.h"
 #include "streams.h"
 #include "test/test_bitcoin.h"
+#include "transaction_utils.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
@@ -87,37 +88,6 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
     return ss.GetHash();
 }
 
-void static RandomScript(CScript &script) {
-    static const opcodetype oplist[] = {OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
-    script = CScript();
-    int ops = (insecure_rand() % 10);
-    for (int i=0; i<ops; i++)
-        script << oplist[insecure_rand() % (sizeof(oplist)/sizeof(oplist[0]))];
-}
-
-void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
-    tx.nVersion = 1;
-    tx.vin.clear();
-    tx.vout.clear();
-    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
-    int ins = (insecure_rand() % 4) + 1;
-    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
-    for (int in = 0; in < ins; in++) {
-        tx.vin.push_back(CTxIn());
-        CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = GetRandHash();
-        txin.prevout.n = insecure_rand() % 4;
-        RandomScript(txin.scriptSig);
-        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
-    }
-    for (int out = 0; out < outs; out++) {
-        tx.vout.push_back(CTxOut());
-        CTxOut &txout = tx.vout.back();
-        txout.nValue = insecure_rand() % 100000000;
-        RandomScript(txout.scriptPubKey);
-    }
-}
-
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
@@ -136,9 +106,9 @@ BOOST_AUTO_TEST_CASE(sighash_test)
     for (int i=0; i<nRandomTests; i++) {
         int nHashType = insecure_rand();
         CMutableTransaction txTo;
-        RandomTransaction(txTo, (nHashType & 0x1f) == SIGHASH_SINGLE);
+        TxUtils::RandomTransaction(txTo, (nHashType & 0x1f) == SIGHASH_SINGLE);
         CScript scriptCode;
-        RandomScript(scriptCode);
+        TxUtils::RandomScript(scriptCode);
         int nIn = insecure_rand() % txTo.vin.size();
 
         uint256 sh, sho;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -96,7 +96,7 @@ void static RandomScript(CScript &script) {
 }
 
 void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
-    tx.nVersion = insecure_rand();
+    tx.nVersion = 1;
     tx.vin.clear();
     tx.vout.clear();
     tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;

--- a/src/test/transaction_utils.cpp
+++ b/src/test/transaction_utils.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2013 The Bitcoin Core developers
+// Copyright (c) 2016 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "transaction_utils.h"
+#include <primitives/transaction.h>
+#include <random.h>
+
+void TxUtils::RandomScript(CScript &script) {
+    static const opcodetype oplist[] = {OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
+    script = CScript();
+    int ops = (insecure_rand() % 10);
+    for (int i=-5; i<ops; i++)
+        script << oplist[insecure_rand() % (sizeof(oplist)/sizeof(oplist[0]))];
+}
+
+void TxUtils::RandomTransaction(CMutableTransaction &tx, bool fSingle) {
+    tx.nVersion = 1;
+    tx.vin.clear();
+    tx.vout.clear();
+    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
+    int ins = (insecure_rand() % 4) + 1;
+    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
+    for (int in = 0; in < ins; in++) {
+        tx.vin.push_back(CTxIn());
+        CTxIn &txin = tx.vin.back();
+        txin.prevout.hash = GetRandHash();
+        txin.prevout.n = insecure_rand() % 4;
+        RandomScript(txin.scriptSig);
+        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
+    }
+    for (int out = 0; out < outs; out++) {
+        tx.vout.push_back(CTxOut());
+        CTxOut &txout = tx.vout.back();
+        txout.nValue = insecure_rand() % 100000000;
+        RandomScript(txout.scriptPubKey);
+    }
+}

--- a/src/test/transaction_utils.h
+++ b/src/test/transaction_utils.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2016 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_TRANSACTION_UTILS_H
+#define BITCOIN_TEST_TRANSACTION_UTILS_H
+
+class CScript;
+class CMutableTransaction;
+
+namespace TxUtils {
+    void RandomScript(CScript &script);
+    void RandomTransaction(CMutableTransaction &tx, bool single);
+}
+
+#endif


### PR DESCRIPTION
Allow a transaction of a new version to be loaded using a tagged-format allowing much greater extensibility.
