### PR TITLE
Re-instate TARGET_OS=linux in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,7 @@ case $host in
      ;;
    *linux*)
      TARGET_OS=linux
+     LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
    *)
      ;;


### PR DESCRIPTION
It is required for out of tree builds.
