### PR TITLE
Add support for double spend proof in FlexTrans

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1125,8 +1125,17 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
     }
 
     extern boost::atomic<bool> flexTransActive;
-    if (flexTransActive && txTo.nVersion == 4)
-        return txTo.GetHash();
+    if (flexTransActive && txTo.nVersion == 4) {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << txTo.GetHash();
+        ss << txTo.vin[nIn].prevout;
+        ss << static_cast<const CScriptBase&>(scriptCode);
+        // ss << amount;
+        ss << txTo.vin[nIn].nSequence;
+        ss << nHashType;
+        return ss.GetHash();
+    }
+
     // Wrapper to serialize only the necessary parts of the transaction being signed
     CTransactionSignatureSerializer txTmp(txTo, scriptCode, nIn, nHashType);
 


### PR DESCRIPTION
This is a simple change in how SigHash is computed, in order to make it possible to generate double spend proof.

The proof would be composed of:
- The "good" transaction.
- The sig script and sighash of the input that is double spent.
- A merkle proof that the prevout is in the sighash.

This way, one can prove a tx has been double spent without spreading the "bad" transaction.
