### PR TITLE
Big blocks

### DIFF
--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -20,7 +20,7 @@ soft-forks, and test that warning alerts are generated.
 VB_PERIOD = 144 # versionbits period length for regtest
 VB_THRESHOLD = 108 # versionbits activation threshold for regtest
 VB_TOP_BITS = 0x20000000
-VB_UNKNOWN_BIT = 27 # Choose a bit unassigned to any deployment
+VB_UNKNOWN_BIT = 26 # Choose a bit unassigned to any deployment
 
 # TestNode: bare-bones "peer".  Used mostly as a conduit for a test to sending
 # p2p messages to a node, generating the messages in the main testing logic.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,7 +72,7 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.nMajorityEnforceBlockUpgrade = 750;
+        consensus.nMajorityEnforceBlockUpgrade = 850;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
         consensus.BIP34Height = 227931;
@@ -110,7 +110,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // Timestamps for forking consensus rule changes:
         // Allow bigger blocks if:
-        consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
+        consensus.nActivateSizeForkMajority = 850; // 85% of hashpower to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24*28; // four week grace period after activation
         consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,7 +72,7 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.nMajorityEnforceBlockUpgrade = 850;
+        consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
         consensus.BIP34Height = 227931;
@@ -110,7 +110,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // Timestamps for forking consensus rule changes:
         // Allow bigger blocks if:
-        consensus.nActivateSizeForkMajority = 850; // 85% of hashpower to activate fork
+        consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
         consensus.nSizeForkGracePeriod = 60*60*24*28; // four week grace period after activation
         consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,12 +6,10 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-/** Block size limit, post-2MB fork */
-static const unsigned int MAX_BLOCK_SIZE = 2000000;
-/** The old block size limit */
-static const unsigned int OLD_MAX_BLOCK_SIZE = 1000000;
-/** pre-2MB-fork limit on signature operations in a block */
-static const unsigned int MAX_BLOCK_SIGOPS = OLD_MAX_BLOCK_SIZE/50;
+/** The maximum allowed size for a serialized block, in bytes (network rule) */
+static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** The maximum allowed number of signature check operations in a block (network rule) */
+static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -60,14 +60,10 @@ struct Params {
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
 
-    /** 2MB fork activation parameters */
+    /** remove blocksize-limit protocol-upgrade activation parameters */
     int nActivateSizeForkMajority;
     int64_t nSizeForkGracePeriod;
     int64_t nSizeForkExpiration;
-
-    int ActivateSizeForkMajority() const { return nActivateSizeForkMajority; }
-    int64_t SizeForkGracePeriod() const { return nSizeForkGracePeriod; }
-    int64_t SizeForkExpiration() const { return nSizeForkExpiration; }
 };
 } // namespace Consensus
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,8 +489,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Minimum bytes per sigop in transactions we relay and mine (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
-    // called excessiveblocksize in BU
-    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks of this size or larger. Unit is multiples of 100KB (default: %u)", DEFAULT_BLOCK_ACCEPT_SIZE));
+    // called excessiveblocksize in the BU client
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), DEFAULT_BLOCK_MIN_SIZE));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,6 +489,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Minimum bytes per sigop in transactions we relay and mine (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    // called excessiveblocksize in BU
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks of this size or larger. Unit is multiples of 100KB (default: %u)", DEFAULT_BLOCK_ACCEPT_SIZE));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), DEFAULT_BLOCK_MIN_SIZE));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3136,7 +3136,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         }
     }
     if (nSizeLimit <= 0)
-        nSizeLimit = DEFAULT_BLOCK_ACCEPT_SIZE * 1E5;
+        nSizeLimit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
 
     if (block.nTime < sizeForkTime.load()) // before the protocol upgrade, limit size.
         nSizeLimit = std::min<std::uint32_t>(nSizeLimit, MAX_BLOCK_SIZE);

--- a/src/main.h
+++ b/src/main.h
@@ -562,7 +562,5 @@ static const unsigned int REJECT_HIGHFEE = 0x100;
 static const unsigned int REJECT_ALREADY_KNOWN = 0x101;
 /** Transaction conflicts with a transaction already known */
 static const unsigned int REJECT_CONFLICT = 0x102;
-/** Maximum size of a block */
-unsigned int MaxBlockSize(uint32_t nBlockTime);
 
 #endif // BITCOIN_MAIN_H

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -152,9 +152,6 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch) {
     // An empty set will not work
     if (nTransactions == 0)
         return uint256();
-    // check for excessively high numbers of transactions
-    if (nTransactions > MAX_BLOCK_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
-        return uint256();
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)
         return uint256();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -95,6 +95,7 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
     if(!pblocktemplate.get())
         return NULL;
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+    pblock->nTime = GetAdjustedTime();
 
     // Create coinbase tx
     CMutableTransaction txNew;
@@ -112,6 +113,22 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
     pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
+
+    // Largest block you're willing to create:
+    // Miners can adjust downwards if they wish to throttle their blocks, for instance, to work around
+    // high orphan rates or other scaling problems.
+    uint32_t nBlockMaxSize = std::max<uint32_t>(1000, GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE));
+    if (pblock->nTime < sizeForkTime.load()) { // before the protocol upgrade, limit size.
+        nBlockMaxSize = std::min<uint32_t>(nBlockMaxSize, MAX_BLOCK_SIZE);
+    }
+
+    // How much of the block should be dedicated to high-priority transactions,
+    // included regardless of the fees they pay
+    const uint32_t nBlockPrioritySize = std::min<uint32_t>(GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE), nBlockMaxSize);
+
+    // Minimum block size you want to create; block will be filled with free transactions
+    // until there are no more or the block reaches this size:
+    const uint32_t nBlockMinSize = std::min<uint32_t>(GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE), nBlockMaxSize);
 
     // Collect memory pool transactions into the block
     CTxMemPool::setEntries inBlock;
@@ -137,7 +154,6 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
         const int nHeight = pindexPrev->nHeight + 1;
-        pblock->nTime = GetAdjustedTime();
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
 
         pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
@@ -147,25 +163,6 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
             pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
 
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
-
-        uint32_t nConsensusMaxSize = MaxBlockSize(pblock->nTime);
-        // Largest block you're willing to create, defaults to being the biggest possible.
-        // Miners can adjust downwards if they wish to throttle their blocks, for instance, to work around
-        // high orphan rates or other scaling problems.
-        uint32_t nBlockMaxSize = (uint32_t) GetArg("-blockmaxsize", nConsensusMaxSize);
-        // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
-        nBlockMaxSize = std::max((uint32_t)1000,
-                                 std::min(nConsensusMaxSize-1000, nBlockMaxSize));
-
-        // How much of the block should be dedicated to high-priority transactions,
-        // included regardless of the fees they pay
-        unsigned int nBlockPrioritySize = GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
-        nBlockPrioritySize = std::min(nBlockMaxSize, nBlockPrioritySize);
-
-        // Minimum block size you want to create; block will be filled with free transactions
-        // until there are no more or the block reaches this size:
-        unsigned int nBlockMinSize = GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
-        nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
 
         int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
                                 ? nMedianTimePast

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -27,6 +27,9 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+/** Default for -blocksizeacceptlimit */
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 20;
+
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -28,7 +28,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 20;
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 2.;
 
 /**
  * Standard script verification flags that standard transactions will comply

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2E6;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -10,11 +10,6 @@
 #include "serialize.h"
 #include "uint256.h"
 
-const uint32_t BIP_009_MASK = 0x20000000;
-const uint32_t BASE_VERSION = 0x20000000;  // Will accept 2MB blocks
-const uint32_t FORK_BIT_2MB = 0x10000000;  // Vote for 2MB fork
-const bool DEFAULT_2MB_VOTE = false;
-
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block
@@ -25,7 +20,8 @@ const bool DEFAULT_2MB_VOTE = false;
 class CBlockHeader
 {
 public:
-    static const int32_t CURRENT_VERSION = BASE_VERSION;
+    static const int32_t CURRENT_VERSION=4;
+    static const uint32_t SIZE_FORK_BIT = 0x8000000;  // signal support for no-block-limite protocol upgrade
 
     // header
     int32_t nVersion;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -619,7 +619,7 @@ static UniValue HardForkMajorityDesc(int minVersion, CBlockIndex* pindex, int nR
         // Always report blocks found as over the threshold once the fork is active
         nFound = nRequired + 1;
         gracePeriodEnds = static_cast<uint64_t>(forkTime);
-        uint256 activationHash = pblocktree->ForkBitActivated(FORK_BIT_2MB);
+        uint256 activationHash = pblocktree->GetSizeRemovalForkActivated();
         assert(activationHash != uint256());
         triggeredAtBlock = activationHash.GetHex();
     } else {
@@ -744,10 +744,10 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("softforks",             softforks));
     obj.push_back(Pair("bip9_softforks", bip9_softforks));
 
-    if (tip->nTime <= consensusParams.SizeForkExpiration())
+    if (tip->nTime <= consensusParams.nSizeForkExpiration)
     {
         UniValue hardforks(UniValue::VARR);
-        hardforks.push_back(HardForkDesc("bip109", BASE_VERSION + FORK_BIT_2MB, tip, consensusParams));
+        hardforks.push_back(HardForkDesc("maxblocksize", CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS, tip, consensusParams));
         obj.push_back(Pair("hardforks", hardforks));
     }
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -583,7 +583,11 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
     result.push_back(Pair("sigoplimit", static_cast<int64_t>(MAX_BLOCK_SIGOPS)));
-    result.push_back(Pair("sizelimit", (int64_t)MaxBlockSize(pblock->nTime)));
+    int64_t sizeLimit = 32E6; // lets have a nice default, the goal is to remove this from the API
+    if (pblock->nTime < sizeForkTime.load()) { // before the protocol upgrade, limit size.
+        sizeLimit = MAX_BLOCK_SIZE;
+    }
+    result.push_back(Pair("sizelimit", sizeLimit));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -83,10 +83,11 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time1)
     CBlockTemplate *pblocktemplate;
 
     uint64_t t = GetTime();
-    uint64_t preforkSize = OLD_MAX_BLOCK_SIZE;
-    uint64_t postforkSize = MAX_BLOCK_SIZE;
+    uint64_t preforkSize = MAX_BLOCK_SIZE;
+    uint64_t postforkSize = 2E6;
     uint64_t tActivate = t;
 
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
     sizeForkTime.store(tActivate);
 
     LOCK(cs_main);
@@ -122,11 +123,12 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time2)
     const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
 
     uint64_t t = GetTime();
-    uint64_t preforkSize = OLD_MAX_BLOCK_SIZE;
-    uint64_t postforkSize = MAX_BLOCK_SIZE;
+    uint64_t preforkSize = MAX_BLOCK_SIZE;
+    uint64_t postforkSize = 2E6;
 
     uint64_t tActivate = t+60*60*24*30;
     sizeForkTime.store(tActivate);
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
 
     LOCK(cs_main);
 
@@ -154,8 +156,9 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_NoActivation)
     const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
 
     uint64_t t = GetTime();
-    uint64_t preforkSize = OLD_MAX_BLOCK_SIZE;
-    uint64_t postforkSize = MAX_BLOCK_SIZE;
+    uint64_t preforkSize = MAX_BLOCK_SIZE;
+    uint64_t postforkSize = 2E6;
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
 
     LOCK(cs_main);
 

--- a/src/test/block_size_tests.cpp
+++ b/src/test/block_size_tests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time1)
     uint64_t postforkSize = 2E6;
     uint64_t tActivate = t;
 
-    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "2"));
     sizeForkTime.store(tActivate);
 
     LOCK(cs_main);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_Time2)
 
     uint64_t tActivate = t+60*60*24*30;
     sizeForkTime.store(tActivate);
-    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "2"));
 
     LOCK(cs_main);
 
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(BigBlockFork_NoActivation)
     uint64_t t = GetTime();
     uint64_t preforkSize = MAX_BLOCK_SIZE;
     uint64_t postforkSize = 2E6;
-    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "20"));
+    mapArgs.insert(std::make_pair<std::string,std::string>("-blocksizeacceptlimit", "2"));
 
     LOCK(cs_main);
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -8,6 +8,8 @@
 
 #include "base58.h"
 #include "netbase.h"
+#include "primitives/block.h"
+#include "versionbits.h"
 
 #include "test/test_bitcoin.h"
 
@@ -396,7 +398,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     // case 2: a block history with only version 4 blocks in the window, but 
     // one bip109 block before that (at genesis, outside window, zero bip109)
     testblocks = freshchain(chain_len);
-    (*testblocks)[0].nVersion = BASE_VERSION + FORK_BIT_2MB;
+    (*testblocks)[0].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
     o1 = r.get_obj();
@@ -415,7 +417,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     testblocks = freshchain(chain_len);
     // add BIP109 blocks, one short of the required majority
     for (int i = 1; i <= chain_len-1; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION + FORK_BIT_2MB;
+        (*testblocks)[i].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     }
     // timestamp the last block as expired w.r.t. BIP109
     (*testblocks)[chain_len-1].nTime = params.nSizeForkExpiration + 1;
@@ -431,12 +433,12 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     // case 4: a block history with (majority-1) BIP9 (0x200000) blocks followed
     //         by the remainder BIP109 blocks, all in window
     testblocks = freshchain(chain_len);
-    // add BASE_VERSION (BIP9) blocks, one short of the required majority
+    // add VERSIONBITS_TOP_BITS (BIP9) blocks, one short of the required majority
     for (int i = 1; i <= params.nActivateSizeForkMajority-1; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION;
+        (*testblocks)[i].nVersion = VERSIONBITS_TOP_BITS;
     }
     for (int i = params.nActivateSizeForkMajority; i <= chain_len-1; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION + FORK_BIT_2MB;
+        (*testblocks)[i].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     }
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
@@ -453,7 +455,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     ///////////////////////////////////////////////////////////////////////////
     // case 5: a v4-block history with one bip109 block at lower end (height 1)
     testblocks = freshchain(chain_len);
-    (*testblocks)[1].nVersion = BASE_VERSION + FORK_BIT_2MB;
+    (*testblocks)[1].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
     o1 = r.get_obj();
@@ -469,7 +471,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     ///////////////////////////////////////////////////////////////////////////
     // case 6: a v4-block history with one bip109 block at tip
     testblocks = freshchain(chain_len);
-    (*testblocks)[testblocks->size()-1].nVersion = BASE_VERSION + FORK_BIT_2MB;
+    (*testblocks)[testblocks->size()-1].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
     o1 = r.get_obj();
@@ -487,7 +489,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     // case 7: full majority of bip109 blocks starting at lower end of window
     testblocks = freshchain(chain_len);
     for (int i = 1; i <= params.nActivateSizeForkMajority; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION + FORK_BIT_2MB;
+        (*testblocks)[i].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     }
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
@@ -506,7 +508,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     // case 8: full window of bip109 blocks (exceeding majority)
     testblocks = freshchain(chain_len);
     for (int i = 1; i <= params.nMajorityWindow; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION + FORK_BIT_2MB;
+        (*testblocks)[i].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS;
     }
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));
@@ -525,7 +527,7 @@ BOOST_AUTO_TEST_CASE(rpc_getblockchaininfo)
     // case 9: full window of blocks with version > 0x30000000 - all of them should count
     testblocks = freshchain(chain_len);
     for (int i = 1; i <= params.nMajorityWindow; i++) {
-        (*testblocks)[i].nVersion = BASE_VERSION + FORK_BIT_2MB + i % 10;
+        (*testblocks)[i].nVersion = CBlockHeader::SIZE_FORK_BIT + VERSIONBITS_TOP_BITS + i % 10;
     }
     chainActive.SetTip(&(*testblocks)[chain_len-1]);
     BOOST_CHECK_NO_THROW(r = CallRPC(string("getblockchaininfo")));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -27,8 +27,7 @@ static const char DB_BEST_BLOCK = 'B';
 static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
-
-static const char DB_FORK_ACTIVATION = 'a';
+static const char DB_SIZE_REMOVAL_FORK_ACTIVATION = 's';
 
 CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, false)
 {
@@ -216,22 +215,16 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
         }
     }
 
-    // Load fork activation info
-    pcursor->Seek(make_pair(DB_FORK_ACTIVATION, 0));
-    while (pcursor->Valid()) {
+    pcursor->Seek(make_pair(DB_SIZE_REMOVAL_FORK_ACTIVATION, 0));
+    if (pcursor->Valid()) {
         try {
             std::pair<char, uint32_t> key;
-            if (pcursor->GetKey(key) && key.first == DB_FORK_ACTIVATION) {
+            if (pcursor->GetKey(key) && key.first == DB_SIZE_REMOVAL_FORK_ACTIVATION) {
                 uint256 blockHash;
-                if (pcursor->GetValue(blockHash)) {
-                    forkActivationMap[key.second] = blockHash;
-                }
-                pcursor->Next();
-            } else {
-                break; // finished loading block index
+                if (pcursor->GetValue(blockHash))
+                    m_sizeRemovalForkActivation = blockHash;
             }
-        }
-        catch (std::exception &e) {
+        } catch (std::exception &e) {
             return error("%s : Deserialize or I/O error - %s", __func__, e.what());
         }
     }
@@ -239,32 +232,17 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
     return true;
 }
 
-uint256 CBlockTreeDB::ForkBitActivated(int32_t nForkVersionBit) const
+void CBlockTreeDB::SetSizeRemovalForkActived(const uint256 &txid)
 {
-    // Returns block at which a supermajority was reached for given
-    // fork version bit.
-    // NOTE! The  max blocksize fork adds a grace period
-    // during which no bigger blocks are allowed; this routine
-    // just keeps track of the hash of the block that
-    // triggers the fork condition
-
-    std::map<int32_t, uint256>::const_iterator it = forkActivationMap.find(nForkVersionBit);
-    if (it != forkActivationMap.end())
-        return it->second;
-
-    return uint256();
+    m_sizeRemovalForkActivation = txid;
 }
 
-bool CBlockTreeDB::ActivateForkBit(int32_t nForkVersionBit, const uint256& blockHash)
+bool CBlockTreeDB::IsSizeRemovalForkActivated() const
 {
-    // Called when a supermajority of blocks (ending with blockHash)
-    // support a rule change
-    // OR if a chain re-org happens around the activation block,
-    // called with uint256(0) to reset the flag in the database.
+    return !m_sizeRemovalForkActivation.IsNull();
+}
 
-    forkActivationMap[nForkVersionBit] = blockHash;
-    if (blockHash == uint256())
-        return Erase(make_pair(DB_FORK_ACTIVATION, nForkVersionBit));
-    else
-        return Write(make_pair(DB_FORK_ACTIVATION, nForkVersionBit), blockHash);
+uint256 CBlockTreeDB::GetSizeRemovalForkActivated() const
+{
+    return m_sizeRemovalForkActivation;
 }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -49,8 +49,6 @@ public:
 private:
     CBlockTreeDB(const CBlockTreeDB&);
     void operator=(const CBlockTreeDB&);
-    std::map<int32_t, uint256> forkActivationMap;
-
 public:
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &fileinfo);
@@ -62,8 +60,13 @@ public:
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts();
-    uint256 ForkBitActivated(int32_t nForkVersionBit) const;
-    bool ActivateForkBit(int32_t nForkVersionBit, const uint256& blockHash);
+
+    void SetSizeRemovalForkActived(const uint256 &txid);
+    bool IsSizeRemovalForkActivated() const;
+    uint256 GetSizeRemovalForkActivated() const;
+
+private:
+    uint256 m_sizeRemovalForkActivation;
 };
 
 #endif // BITCOIN_TXDB_H


### PR DESCRIPTION
This reverts BIP109. Classic will no longer vote for BIP109.

This reuses the code and starts voting for a new bit which is a protocol
upgrade and the only change in that one is that the maximum block size is
removed.

This new fork is activated using bit 26, while requiring signalling for
BIP9 making the block version 0x28000000 When 75% of 1000 blocks have this
bit set we lock in this change and have a 4 week wait period.
After that period blocks no longer have a size limit.

Miners can continue to use the -blockmaxsize argument or bitcoin.conf
setting to limit the size of blocks they generate!  All nodes can also use
the `-blocksizeacceptlimit` option to limit the size of the blocks accepted
from other miners.

This change simplifies some of the designs that were introduced for BIP9, like the overloading of the  IsSuperMajority method and the txdb getter/setter is now made substantially simpler too. Overdesigns are good to remove.

Last, I moved the fork-bit to be namespaced inside CBlockHeader, being a tiny little bit more structured instead of everything in the global namespace.
