### PR TITLE
Follow XDG Base Directory Spec for config files

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -474,7 +474,16 @@ boost::filesystem::path GetDefaultDataDir()
     return pathRet / "Library/Application Support/Bitcoin";
 #else
     // Unix
-    return pathRet / ".bitcoin";
+    fs::path legacyPath = pathRet / ".bitcoin";
+    if (fs::exists(legacyPath))
+        return legacyPath;
+    fs::path configDir;
+    char* pszConfigHome = getenv("XDG_CONFIG_HOME");
+    if (pszConfigHome == NULL || strlen(pszConfigHome) == 0)
+        configDir = pathRet / ".config";
+    else
+        configDir = fs::path(pszConfigHome);
+    return configDir / "bitcoin";
 #endif
 #endif
 }


### PR DESCRIPTION
Modifies the GetDefaultDataDir method to comply with the XDG Base Directory Specification (https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
On Unix systems only:
 - If \~/.bitcoin exists, return '\~/.bitcoin` (this ensures backward compatibility)
 - If the XDG_CONFIG_HOME environment variable is set, return '$XDG_CONFIG_HOME/bitcoin'
 - Otherwise, return '~/.config/bitcoin'.

This resolves Issue #179