### PR TITLE
Produce error on unrecognized command-line args

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ BITCOIN_CORE_H = \
   AdminServer.h \
   AdminRPCBinding.h \
   addrman.h \
+  allowed_args.h \
   amount.h \
   Application.h \
   arith_uint256.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -311,6 +311,7 @@ libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
   support/pagelocker.cpp \
+  allowed_args.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
   compat/glibc_sanity.cpp \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Bitcoin Classic developers
+// Copyright (c) 2017 Stephen McCarthy
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) 2017 The Bitcoin Classic developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "allowed_args.h"
+
+#include "tinyformat.h"
+#include "util.h"
+
+#include <set>
+
+const std::set<std::string> HELP_ARGS
+{
+  "?",
+  "h",
+  "help",
+  "version"
+};
+
+const std::set<std::string> BITCOIND_ARGS
+{
+#ifdef ENABLE_WALLET
+    "disablewallet",
+    "fallbackfee",
+    "keypool",
+    "maxtxfee",
+    "mintxfee",
+    "paytxfee",
+    "rescan",
+    "salvagewallet",
+    "sendfreetransactions",
+    "spendzeroconfchange",
+    "txconfirmtarget",
+    "upgradewallet",
+    "wallet",
+    "walletbroadcast",
+    "walletnotify",
+    "zapwallettxes",
+#endif
+#if ENABLE_ZMQ
+    "zmqpubhashblock",
+    "zmqpubhashtx",
+    "zmqpubrawblock",
+    "zmqpubrawtx"
+#endif
+#ifdef USE_UPNP
+    "upnp",
+#endif
+#ifndef WIN32
+    "daemon",
+    "pid",
+#endif
+    "acceptnonstdtxn",
+    "addnode",
+    "admincookiefile",
+    "adminserver",
+    "alertnotify",
+    "banscore",
+    "bantime",
+    "bind",
+    "blockmaxsize",
+    "blockminsize",
+    "blocknotify",
+    "blockprioritysize",
+    "blocksizeacceptlimit",
+    "blocksonly",
+    "blockversion",
+    "bytespersigop",
+    "checkblockindex",
+    "checkblocks",
+    "checklevel",
+    "checkmempool",
+    "checkpoints",
+    "conf",
+    "connect",
+    "datacarrier",
+    "datacarriersize",
+    "datadir",
+    "dbcache",
+    "dblogsize",
+    "debug",
+    "disablesafemode",
+    "discover",
+    "dns",
+    "dnsseed",
+    "dropmessagestest",
+    "enforcenodebloom",
+    "excessiveblocksize",
+    "externalip",
+    "flextrans",
+    "flushwallet",
+    "forcednsseed",
+    "fuzzmessagestest",
+    "gen",
+    "gencoinbase",
+    "genproclimit",
+    "help-debug",
+    "limitancestorcount",
+    "limitancestorsize",
+    "limitdescendantcount",
+    "limitdescendantsize",
+    "limitfreerelay",
+    "listen",
+    "listenonion",
+    "loadblock",
+    "logips",
+    "logtimemicros",
+    "logtimestamps",
+    "maxconnections",
+    "maxmempool",
+    "maxorphantx",
+    "maxreceivebuffer",
+    "maxsendbuffer",
+    "maxsigcachesize",
+    "maxuploadtarget",
+    "mempoolexpiry",
+    "minrelaytxfee",
+    "mocktime",
+    "onion",
+    "onlynet",
+    "par",
+    "peerbloomfilters",
+    "permitbaremultisig",
+    "port",
+    "printpriority",
+    "printtoconsole",
+    "privdb",
+    "proxy",
+    "proxyrandomize",
+    "prune",
+    "reindex",
+    "relaypriority",
+    "regtest",
+    "rest",
+    "rpcallowip",
+    "rpcauth",
+    "rpcbind",
+    "rpccookiefile",
+    "rpcpassword",
+    "rpcport",
+    "rpcservertimeout",
+    "rpcthreads",
+    "rpcuser",
+    "rpcworkqueue",
+    "seednode",
+    "server",
+    "shrinkdebugfile",
+    "stopafterblockimport",
+    "testnet",
+    "testnet-ft",
+    "testsafemode",
+    "timeout",
+    "torcontrol",
+    "torpassword",
+    "txindex",
+    "uacomment",
+    "use-thinblocks",
+    "version",
+    "whitebind",
+    "whitelist",
+    "whitelistforcerelay",
+    "whitelistrelay"
+};
+
+const std::set<std::string> BITCOIN_QT_ARGS
+{
+    "allowselfsignedrootcertificates",
+    "choosedatadir",
+    "lang",
+    "min",
+    "resetguisettings",
+    "rootcertificates",
+    "splash",
+    "uiplatform"
+};
+
+const std::set<std::string> BITCOIN_CLI_ARGS
+{
+    "conf",
+    "datadir",
+    "rpcclienttimeout",
+    "rpcconnect",
+    "rpcpassword",
+    "rpcport",
+    "rpcuser",
+    "rpcwait"
+};
+
+const std::set<std::string> BITCOIN_TX_ARGS
+{
+    "create",
+    "json",
+    "txid"
+};
+
+void unrecognizedOption(const std::string& strArg)
+{
+    throw std::runtime_error(strprintf(_("unrecognized option '%s'"), strArg));
+}
+
+void AllowedArgs::BitcoinCli(const std::string& strArg)
+{
+    if (!HELP_ARGS.count(strArg) &&
+        !BITCOIN_CLI_ARGS.count(strArg))
+    {
+        unrecognizedOption(strArg);
+    }
+}
+
+void AllowedArgs::Bitcoind(const std::string& strArg)
+{
+    if (!HELP_ARGS.count(strArg) &&
+        !BITCOIND_ARGS.count(strArg))
+    {
+        unrecognizedOption(strArg);
+    }
+}
+
+void AllowedArgs::BitcoinQt(const std::string& strArg)
+{
+    if (!HELP_ARGS.count(strArg) &&
+        !BITCOIND_ARGS.count(strArg) &&
+        !BITCOIN_QT_ARGS.count(strArg))
+    {
+        unrecognizedOption(strArg);
+    }
+}
+
+void AllowedArgs::BitcoinTx(const std::string& strArg)
+{
+    if (!HELP_ARGS.count(strArg) &&
+        !BITCOIN_TX_ARGS.count(strArg))
+    {
+        unrecognizedOption(strArg);
+    }
+}
+
+void AllowedArgs::ConfigFile(const std::string& strArg)
+{
+    if (!HELP_ARGS.count(strArg) &&
+        !BITCOIND_ARGS.count(strArg) &&
+        !BITCOIN_QT_ARGS.count(strArg) &&
+        !BITCOIN_CLI_ARGS.count(strArg))
+    {
+        unrecognizedOption(strArg);
+    }
+}

--- a/src/allowed_args.h
+++ b/src/allowed_args.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 The Bitcoin Classic developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ALLOWED_ARGS_H
+#define BITCOIN_ALLOWED_ARGS_H
+
+#include <functional>
+
+typedef std::function<void(const std::string& strArg)> CheckArgFunc;
+
+class AllowedArgs
+{
+public:
+
+    static void BitcoinCli(const std::string& strArg);
+    static void Bitcoind(const std::string& strArg);
+    static void BitcoinQt(const std::string& strArg);
+    static void BitcoinTx(const std::string& strArg);
+    static void ConfigFile(const std::string& strArg);
+};
+
+#endif // BITCOIN_ALLOWED_ARGS_H

--- a/src/allowed_args.h
+++ b/src/allowed_args.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Bitcoin Classic developers
+// Copyright (c) 2017 Stephen McCarthy
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -68,7 +68,12 @@ static bool AppInitRPC(int argc, char* argv[])
     //
     // Parameters
     //
-    ParseParameters(argc, argv);
+    try {
+        ParseParameters(argc, argv, AllowedArgs::BitcoinCli);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Error parsing program options: %s\n", e.what());
+        return false;
+    }
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Bitcoin Classic RPC client version") + " " + FormatFullVersion() + "\n";
         if (!mapArgs.count("-version")) {
@@ -98,11 +103,6 @@ static bool AppInitRPC(int argc, char* argv[])
         SelectBaseParams(ChainNameFromCommandLine());
     } catch (const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());
-        return false;
-    }
-    if (GetBoolArg("-rpcssl", false))
-    {
-        fprintf(stderr, "Error: SSL mode for RPC (-rpcssl) is no longer supported.\n");
         return false;
     }
     return true;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -32,7 +32,12 @@ static bool AppInitRawTx(int argc, char* argv[])
     //
     // Parameters
     //
-    ParseParameters(argc, argv);
+    try {
+        ParseParameters(argc, argv, AllowedArgs::BitcoinTx);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Error parsing program options: %s\n", e.what());
+        return false;
+    }
 
     flexTransActive = GetBoolArg("-flextrans", false);
 
@@ -46,11 +51,17 @@ static bool AppInitRawTx(int argc, char* argv[])
 
     fCreateBlank = GetBoolArg("-create", false);
 
-    if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
+    if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version"))
     {
         // First part of help message is specific to this utility
-        std::string strUsage = _("Bitcoin Classic bitcoin-tx utility version") + " " + FormatFullVersion() + "\n\n" +
-            _("Usage:") + "\n" +
+        std::string strUsage = _("Bitcoin Classic bitcoin-tx utility version") + " " + FormatFullVersion() + "\n";
+
+        fprintf(stdout, "%s", strUsage.c_str());
+
+        if (mapArgs.count("-version"))
+            return false;
+
+        strUsage = "\n" + _("Usage:") + "\n" +
               "  bitcoin-tx [options] <hex-tx> [commands]  " + _("Update hex-encoded bitcoin transaction") + "\n" +
               "  bitcoin-tx [options] -create [commands]   " + _("Create hex-encoded bitcoin transaction") + "\n" +
               "\n";

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -69,7 +69,12 @@ bool AppInit(int argc, char* argv[])
     // Parameters
     //
     // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
-    ParseParameters(argc, argv);
+    try {
+        ParseParameters(argc, argv, AllowedArgs::Bitcoind);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Error parsing program options: %s\n", e.what());
+        return false;
+    }
 
     // Process help and version before taking care about datadir
     if (mapArgs.count("-?") || mapArgs.count("-h") ||  mapArgs.count("-help") || mapArgs.count("-version"))

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -383,13 +383,6 @@ bool InitHTTPServer()
     if (!InitHTTPAllowList())
         return false;
 
-    if (GetBoolArg("-rpcssl", false)) {
-        uiInterface.ThreadSafeMessageBox(
-            "SSL mode for RPC (-rpcssl) is no longer supported.",
-            "", CClientUIInterface::MSG_ERROR);
-        return false;
-    }
-
     // Redirect libevent's logging to our own log
     event_set_log_callback(&libevent_log_cb);
 #if LIBEVENT_VERSION_NUMBER >= 0x02010100

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -490,6 +490,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
     // called excessiveblocksize in the BU client
     strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
+    strUsage += HelpMessageOpt("-use-thinblocks", "Enable thin blocks to speed up the relay of blocks (default: 1)");
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), DEFAULT_BLOCK_MIN_SIZE));
@@ -871,22 +872,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     const vector<string>& categories = mapMultiArgs["-debug"];
     if (GetBoolArg("-nodebug", false) || find(categories.begin(), categories.end(), string("0")) != categories.end())
         fDebug = false;
-
-    // Check for -debugnet
-    if (GetBoolArg("-debugnet", false))
-        InitWarning(_("Unsupported argument -debugnet ignored, use -debug=net."));
-    // Check for -socks - as this is a privacy risk to continue, exit here
-    if (mapArgs.count("-socks"))
-        return InitError(_("Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported."));
-    // Check for -tor - as this is a privacy risk to continue, exit here
-    if (GetBoolArg("-tor", false))
-        return InitError(_("Unsupported argument -tor found, use -onion."));
-
-    if (GetBoolArg("-benchmark", false))
-        InitWarning(_("Unsupported argument -benchmark ignored, use -debug=bench."));
-
-    if (GetBoolArg("-whitelistalwaysrelay", false))
-        InitWarning(_("Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay."));
 
     // Checkmempool and checkblockindex default to true in regtest mode
     int ratio = std::min<int>(std::max<int>(GetArg("-checkmempool", chainparams.DefaultConsistencyChecks() ? 1 : 0), 0), 1000000);

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -29,14 +29,14 @@ static void ResetArgs(const std::string& strArg)
     BOOST_FOREACH(std::string& s, vecArg)
         vecChar.push_back(s.c_str());
 
-    ParseParameters(vecChar.size(), &vecChar[0]);
+    ParseParameters(vecChar.size(), &vecChar[0], AllowedArgs::Bitcoind);
 }
 
 BOOST_AUTO_TEST_CASE(boolarg)
 {
-    ResetArgs("-foo");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    ResetArgs("-listen");
+    BOOST_CHECK(GetBoolArg("-listen", false));
+    BOOST_CHECK(GetBoolArg("-listen", true));
 
     BOOST_CHECK(!GetBoolArg("-fo", false));
     BOOST_CHECK(GetBoolArg("-fo", true));
@@ -44,120 +44,120 @@ BOOST_AUTO_TEST_CASE(boolarg)
     BOOST_CHECK(!GetBoolArg("-fooo", false));
     BOOST_CHECK(GetBoolArg("-fooo", true));
 
-    ResetArgs("-foo=0");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("-listen=0");
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
-    ResetArgs("-foo=1");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    ResetArgs("-listen=1");
+    BOOST_CHECK(GetBoolArg("-listen", false));
+    BOOST_CHECK(GetBoolArg("-listen", true));
 
     // New 0.6 feature: auto-map -nosomething to !-something:
-    ResetArgs("-nofoo");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("-nolisten");
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
-    ResetArgs("-nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("-nolisten=1");
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
-    ResetArgs("-foo -nofoo");  // -nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("-listen -nolisten");  // -nolisten should win
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
-    ResetArgs("-foo=1 -nofoo=1");  // -nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("-listen=1 -nolisten=1");  // -nolisten should win
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
-    ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    ResetArgs("-listen=0 -nolisten=0");  // -nolisten=0 should win
+    BOOST_CHECK(GetBoolArg("-listen", false));
+    BOOST_CHECK(GetBoolArg("-listen", true));
 
     // New 0.6 feature: treat -- same as -:
-    ResetArgs("--foo=1");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    ResetArgs("--listen=1");
+    BOOST_CHECK(GetBoolArg("-listen", false));
+    BOOST_CHECK(GetBoolArg("-listen", true));
 
-    ResetArgs("--nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    ResetArgs("--nolisten=1");
+    BOOST_CHECK(!GetBoolArg("-listen", false));
+    BOOST_CHECK(!GetBoolArg("-listen", true));
 
 }
 
 BOOST_AUTO_TEST_CASE(stringarg)
 {
     ResetArgs("");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", "eleven"), "eleven");
 
-    ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+    ResetArgs("-uacomment -listen");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", "eleven"), "");
 
-    ResetArgs("-foo=");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+    ResetArgs("-uacomment=");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", "eleven"), "");
 
-    ResetArgs("-foo=11");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "11");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "11");
+    ResetArgs("-uacomment=11");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "11");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", "eleven"), "11");
 
-    ResetArgs("-foo=eleven");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "eleven");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+    ResetArgs("-uacomment=eleven");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "eleven");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", "eleven"), "eleven");
 
 }
 
 BOOST_AUTO_TEST_CASE(intarg)
 {
     ResetArgs("");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 11);
-    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 0);
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 11), 11);
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 0), 0);
 
-    ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 0);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+    ResetArgs("-maxconnections -maxreceivebuffer");
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 11), 0);
+    BOOST_CHECK_EQUAL(GetArg("-maxreceivebuffer", 11), 0);
 
-    ResetArgs("-foo=11 -bar=12");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 11);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 12);
+    ResetArgs("-maxconnections=11 -maxreceivebuffer=12");
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 0), 11);
+    BOOST_CHECK_EQUAL(GetArg("-maxreceivebuffer", 11), 12);
 
-    ResetArgs("-foo=NaN -bar=NotANumber");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 1), 0);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+    ResetArgs("-maxconnections=NaN -maxreceivebuffer=NotANumber");
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 1), 0);
+    BOOST_CHECK_EQUAL(GetArg("-maxreceivebuffer", 11), 0);
 }
 
 BOOST_AUTO_TEST_CASE(doubledash)
 {
-    ResetArgs("--foo");
-    BOOST_CHECK_EQUAL(GetBoolArg("-foo", false), true);
+    ResetArgs("--listen");
+    BOOST_CHECK_EQUAL(GetBoolArg("-listen", false), true);
 
-    ResetArgs("--foo=verbose --bar=1");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "verbose");
-    BOOST_CHECK_EQUAL(GetArg("-bar", 0), 1);
+    ResetArgs("--uacomment=verbose --maxconnections=1");
+    BOOST_CHECK_EQUAL(GetArg("-uacomment", ""), "verbose");
+    BOOST_CHECK_EQUAL(GetArg("-maxconnections", 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(boolargno)
 {
-    ResetArgs("-nofoo");
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    ResetArgs("-nolisten");
+    BOOST_CHECK(!GetBoolArg("-listen", true));
+    BOOST_CHECK(!GetBoolArg("-listen", false));
 
-    ResetArgs("-nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    ResetArgs("-nolisten=1");
+    BOOST_CHECK(!GetBoolArg("-listen", true));
+    BOOST_CHECK(!GetBoolArg("-listen", false));
 
-    ResetArgs("-nofoo=0");
-    BOOST_CHECK(GetBoolArg("-foo", true));
-    BOOST_CHECK(GetBoolArg("-foo", false));
+    ResetArgs("-nolisten=0");
+    BOOST_CHECK(GetBoolArg("-listen", true));
+    BOOST_CHECK(GetBoolArg("-listen", false));
 
-    ResetArgs("-foo --nofoo"); // --nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    ResetArgs("-listen --nolisten"); // --nolisten should win
+    BOOST_CHECK(!GetBoolArg("-listen", true));
+    BOOST_CHECK(!GetBoolArg("-listen", false));
 
-    ResetArgs("-nofoo -foo"); // foo always wins:
-    BOOST_CHECK(GetBoolArg("-foo", true));
-    BOOST_CHECK(GetBoolArg("-foo", false));
+    ResetArgs("-nolisten -listen"); // -listen always wins:
+    BOOST_CHECK(GetBoolArg("-listen", true));
+    BOOST_CHECK(GetBoolArg("-listen", false));
 }
 
 BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -96,26 +96,32 @@ BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
 
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
 {
-    const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
+    const char *argv_test[] = {"-ignored", "-reindex", "-txindex", "-connect=argument", "-connect=multiple", "f", "-d=e"};
 
-    ParseParameters(0, (char**)argv_test);
+    ParseParameters(0, (char**)argv_test, AllowedArgs::Bitcoind);
     BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
-    ParseParameters(1, (char**)argv_test);
+    ParseParameters(1, (char**)argv_test, AllowedArgs::Bitcoind);
     BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
-    ParseParameters(5, (char**)argv_test);
+    ParseParameters(5, (char**)argv_test, AllowedArgs::Bitcoind);
     // expectation: -ignored is ignored (program name argument),
-    // -a, -b and -ccc end up in map, -d ignored because it is after
+    // -reindex, -txindex and -connect end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
     BOOST_CHECK(mapArgs.size() == 3 && mapMultiArgs.size() == 3);
-    BOOST_CHECK(mapArgs.count("-a") && mapArgs.count("-b") && mapArgs.count("-ccc")
+    BOOST_CHECK(mapArgs.count("-reindex") && mapArgs.count("-txindex") && mapArgs.count("-connect")
                 && !mapArgs.count("f") && !mapArgs.count("-d"));
-    BOOST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc")
+    BOOST_CHECK(mapMultiArgs.count("-reindex") && mapMultiArgs.count("-txindex") && mapMultiArgs.count("-connect")
                 && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
 
-    BOOST_CHECK(mapArgs["-a"] == "" && mapArgs["-ccc"] == "multiple");
-    BOOST_CHECK(mapMultiArgs["-ccc"].size() == 2);
+    BOOST_CHECK(mapArgs["-reindex"] == "" && mapArgs["-connect"] == "multiple");
+    BOOST_CHECK(mapMultiArgs["-connect"].size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(util_ParseParameters_unrecognized)
+{
+    const char *argv_test[] = {"-ignored", "-unrecognized_arg"};
+    BOOST_CHECK_THROW(ParseParameters(2, (char**)argv_test, AllowedArgs::Bitcoind), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(util_GetArg)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -342,7 +342,7 @@ static void InterpretNegativeSetting(std::string& strKey, std::string& strValue)
     }
 }
 
-void ParseParameters(int argc, const char* const argv[])
+void ParseParameters(int argc, const char* const argv[], CheckArgFunc checkArgFunc)
 {
     mapArgs.clear();
     mapMultiArgs.clear();
@@ -371,6 +371,7 @@ void ParseParameters(int argc, const char* const argv[])
         if (str.length() > 1 && str[1] == '-')
             str = str.substr(1);
         InterpretNegativeSetting(str, strValue);
+        checkArgFunc(str.substr(1));
 
         mapArgs[str] = strValue;
         mapMultiArgs[str].push_back(strValue);
@@ -581,6 +582,7 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
         string strKey = string("-") + it->string_key;
         string strValue = it->value[0];
         InterpretNegativeSetting(strKey, strValue);
+        AllowedArgs::ConfigFile(strKey.substr(1));
         if (mapSettingsRet.count(strKey) == 0)
             mapSettingsRet[strKey] = strValue;
         mapMultiSettingsRet[strKey].push_back(strValue);

--- a/src/util.h
+++ b/src/util.h
@@ -14,6 +14,7 @@
 #include "config/bitcoin-config.h"
 #endif
 
+#include "allowed_args.h"
 #include "compat.h"
 #include "tinyformat.h"
 #include "utiltime.h"
@@ -114,7 +115,7 @@ static inline bool error(const char* format)
 }
 
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
-void ParseParameters(int argc, const char*const argv[]);
+void ParseParameters(int argc, const char*const argv[], CheckArgFunc checkArgFunc);
 void FileCommit(FILE *fileout);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);


### PR DESCRIPTION
Partially resolves #172

Output an error message and exit the program if there are any unrecognized command-line args or any unrecognized parameters in the config file.

A new class is created: `AllowedArgs`. This class contains sets that define which arguments are allowed for each executable. It also defines a function for each of the executable types. These functions are passed in as a new required argument to the `ParseParameters` method in util.cpp.

All tests are updated to use allowed arguments. A new test is created which exercises parsing an invalid argument.

Several custom error messages for invalid args are removed, since the checking is now done earlier in the program execution.

In order to determine the set of allowed arguments, I primarily looked at the help documentation in the following locations:
  - `bitcoind`: init.cpp
  - `bitcoin-qt`: qt/utilitydialog.cpp (combined with the bitcoind args)
  - `bitcoin-cli`: bitcoin-cli.cpp. 
  - `bitcoin-tx`: bitcoin-tx.cpp.

In addition, I grepped through the codebase using the following searches:
  - `grep -r --exclude-dir=test -E "Get(Bool)?Arg\(\"\S*" .`
  - `grep -r --exclude-dir=test -E "map(Mutli)?Args.*?\"" .`

Using these searches, I found 2 additional allowed arguments: "excessiveblocksize", and "use-thinblocks". I added help documentation to init.cpp for "use-thinblocks".

This change also fixes 2 related issues that came up:
  - Add support for a "-version" argument to `bitcoin-tx`. This standardizes the set of help arguments across all executables.
  - In qt/bitcoin.cpp, define `BitcoinApplication` before parsing the command-line options. This allows for any command-line parsing error messages to be shown in a gui window. This also fixes a bug that prevented the 'uiplatform' argument from taking effect if it was specified in the config file.

This change only checks for unrecognized args, it does not do any type checking on the values of the arguments. This is already quite large, so I wanted to limit the scope somewhat. However, it is designed such that adding support for type checking should be do-able without a major redesign - most of the future changes will simply need to be made to the `AllowedArgs` class.