### PR TITLE
[QT] Bugfix: ensure tray icon menu is not empty

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -531,7 +531,6 @@ void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)
     QString toolTip = tr("Bitcoin Classic client") + " " + networkStyle->getTitleAddText();
     trayIcon->setToolTip(toolTip);
     trayIcon->setIcon(networkStyle->getTrayAndWindowIcon());
-    trayIcon->show();
 #endif
 
     notificator = new Notificator(QApplication::applicationName(), trayIcon, this);
@@ -546,6 +545,7 @@ void BitcoinGUI::createTrayIconMenu()
 
     trayIconMenu = new QMenu(this);
     trayIcon->setContextMenu(trayIconMenu);
+    trayIcon->show();
 
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(trayIconActivated(QSystemTrayIcon::ActivationReason)));


### PR DESCRIPTION
On my system (running Ubuntu 16.04, with the XFCE desktop), I am experiencing a bug in which the tray icon menu does not contain any content.

This change resolves this bug by moving the `trayIcon->show()` call to be made after the `trayIcon->setContextMenu(trayIconMenu)` call.