### PR TITLE
Gui: Make 'Abort' the default modal box button

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -842,6 +842,8 @@ void BitcoinGUI::message(const QString &title, const QString &message, unsigned 
 
         showNormalIfMinimized();
         QMessageBox mBox((QMessageBox::Icon)nMBoxIcon, strTitle, message, buttons, this);
+        if (style & CClientUIInterface::BTN_ABORT)
+            mBox.setDefaultButton(QMessageBox::Abort);
         int r = mBox.exec();
         if (ret != NULL)
             *ret = r == QMessageBox::Ok;


### PR DESCRIPTION
There is a modal dialog box that prompts users to reindex the blockchain in the event of a change to the `-txindex` or `-prune` options. Depending on the UI style, it is currently possible for the 'OK' button to be the default option. When this dialog box pops up it steals keyboard focus, and therefore it is easy to accidentally activate the default option.

![screenshot_2017-02-02_17-11-19](https://cloud.githubusercontent.com/assets/587471/22576151/d7d38aca-e96e-11e6-869b-86761cc12a3e.png)

Since accidentally aborting is preferable to accidentally starting a non-cancelable and time-consuming rescan operation, this change will make the 'Abort' button the default dialog box button if it is present.

This change will affect all dialog boxes created using the `uiInterface.ThreadSafeMessageBox` method. However, currently, the only place the 'Abort' button is used is in the dialog box described above. I felt that making a configurable default button went beyond the necessary scope for this change.