### PR TITLE
Remove explicit check for -nodebug arg

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -655,7 +655,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     fDebug = !mapMultiArgs["-debug"].empty();
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages
     const vector<string>& categories = mapMultiArgs["-debug"];
-    if (GetBoolArg("-nodebug", false) || find(categories.begin(), categories.end(), string("0")) != categories.end())
+    if (find(categories.begin(), categories.end(), string("0")) != categories.end())
         fDebug = false;
 
     // Checkmempool and checkblockindex default to true in regtest mode


### PR DESCRIPTION
The InterpretNegativeSetting function is applied to all program options, and will turn -nodebug into -debug=0. Therefore, there is no need to explicitly check for -nodebug.