### PR TITLE
Use GetBoolArg for -resetguisettings

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -662,7 +662,7 @@ int main(int argc, char *argv[])
     // Allow parameter interaction before we create the options model
     app.parameterSetup();
     // Load GUI settings from QSettings
-    app.createOptionsModel(mapArgs.count("-resetguisettings") != 0);
+    app.createOptionsModel(GetBoolArg("-resetguisettings", false));
 
     // Subscribe to global signals from core
     uiInterface.InitMessage.connect(InitMessage);


### PR DESCRIPTION
Use `GetBoolArg` rather than `mapArgs.count` for boolean `-resetguisettings` arg. This prevents `-resetguisettings=0` from resetting the gui settings.