### PR TITLE
Allow true/false yes/no t/f y/n for bool args

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -116,7 +116,7 @@ std::string AllowedArgs::helpMessage() const
 // CheckValueFunc functions
 //
 
-static const std::set<char> boolChars{'0', '1'};
+static const std::set<std::string> boolStrings{"", "1", "0", "t", "f", "y", "n", "true", "false", "yes", "no"};
 static const std::set<char> intChars{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 static const std::set<char> amountChars{'.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
@@ -130,9 +130,7 @@ static bool validateString(const std::string& str, const std::set<char>& validCh
 
 static bool optionalBool(const std::string& str)
 {
-    if (str.empty())
-        return true;
-    return validateString(str, boolChars);
+    return (boolStrings.count(str) != 0);
 }
 
 static bool requiredStr(const std::string& str)

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -44,13 +44,17 @@ BOOST_AUTO_TEST_CASE(boolarg)
     BOOST_CHECK(!GetBoolArg("-fooo", false));
     BOOST_CHECK(GetBoolArg("-fooo", true));
 
-    ResetArgs("-listen=0");
-    BOOST_CHECK(!GetBoolArg("-listen", false));
-    BOOST_CHECK(!GetBoolArg("-listen", true));
+    for (auto strValue : std::list<std::string>{"0", "f", "n", "false", "no"}) {
+        ResetArgs("-listen=" + strValue);
+        BOOST_CHECK(!GetBoolArg("-listen", false));
+        BOOST_CHECK(!GetBoolArg("-listen", true));
+    }
 
-    ResetArgs("-listen=1");
-    BOOST_CHECK(GetBoolArg("-listen", false));
-    BOOST_CHECK(GetBoolArg("-listen", true));
+    for (auto strValue : std::list<std::string>{"", "1", "t", "y", "true", "yes"}) {
+        ResetArgs("-listen=" + strValue);
+        BOOST_CHECK(GetBoolArg("-listen", false));
+        BOOST_CHECK(GetBoolArg("-listen", true));
+    }
 
     // New 0.6 feature: auto-map -nosomething to !-something:
     ResetArgs("-nolisten");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -324,12 +324,12 @@ int LogPrintStr(const std::string &str)
     return ret;
 }
 
+static const std::set<std::string> affirmativeStrings{"", "1", "t", "y", "true", "yes"};
+
 /** Interpret string as boolean, for argument parsing */
 static bool InterpretBool(const std::string& strValue)
 {
-    if (strValue.empty())
-        return true;
-    return (atoi(strValue) != 0);
+    return (affirmativeStrings.count(strValue) != 0);
 }
 
 /** Turn -noX into -X=0 */


### PR DESCRIPTION
Modify util's InterpretBool and AllowedArg's optionalBool function to allow true/false yes/no t/f y/n in addition to the existing 1/0.