### PR TITLE
Remove unnecessary output from sighash_tests

### DIFF
--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -31,7 +31,6 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
     static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
     if (nIn >= txTo.vin.size())
     {
-        printf("ERROR: SignatureHash(): nIn=%d out of range\n", nIn);
         return one;
     }
     CMutableTransaction txTmp(txTo);
@@ -62,7 +61,6 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
         unsigned int nOut = nIn;
         if (nOut >= txTmp.vout.size())
         {
-            printf("ERROR: SignatureHash(): nOut=%d out of range\n", nOut);
             return one;
         }
         txTmp.vout.resize(nOut+1);


### PR DESCRIPTION
A recent change to `TxUtils::RandomTransaction` caused the `SignatureHashOld` function in sighash_tests to start outputting "ERROR: SignatureHash(): nOut=%d out of range". The test is passing, but just exercising different branches, which causes the output.

This change removes the unnecessary output.