### PR TITLE
Consistently use uint32_t for blockSizeAcceptLimit

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -387,7 +387,7 @@ static void addNodeRelayOptions(AllowedArgs& allowedArgs)
     allowedArgs
         .addHeader(_("Node relay options:"))
         .addDebugArg("acceptnonstdtxn", optionalBool, strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", true))
-        .addArg("blocksizeacceptlimit=<n>", requiredAmount, strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE))
+        .addArg("blocksizeacceptlimit=<n>", requiredAmount, strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE / 1e6))
         .addArg("bytespersigop=<n>", requiredInt, strprintf(_("Minimum bytes per sigop in transactions we relay and mine (default: %u)"), DEFAULT_BYTES_PER_SIGOP))
         .addArg("datacarrier", optionalBool, strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER))
         .addArg("datacarriersize=<n>", requiredInt, strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -625,7 +625,7 @@ Mining::Mining()
     : m_minerThreads(0)
 {
     // read args to create m_coinbaseComment
-    std::int32_t sizeLimit = Policy::blockSizeAcceptLimit();
+    std::uint32_t sizeLimit = Policy::blockSizeAcceptLimit();
 
     std::stringstream ss;
     ss << std::fixed;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -185,9 +185,9 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
-int32_t Policy::blockSizeAcceptLimit()
+uint32_t Policy::blockSizeAcceptLimit()
 {
-    int limit = -1;
+    uint32_t limit = -1;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
     if (userlimit == mapArgs.end()) { // fallback to the BitcoinUnlimited name.
        limit = GetArg("-excessiveblocksize", -1);
@@ -198,12 +198,12 @@ int32_t Policy::blockSizeAcceptLimit()
         if (limitInMB <= 0) {
             LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());
         } else {
-            limit = static_cast<int32_t>(round(limitInMB * 1000000));
+            limit = static_cast<uint32_t>(round(limitInMB * 1000000));
             limit -= (limit % 100000); // only one digit behind the dot was allowed
         }
     }
     if (limit <= 0)
-        limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+        limit = DEFAULT_BLOCK_ACCEPT_SIZE;
     if (limit < 1000000)
         LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -28,7 +28,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7;
+static const uint32_t DEFAULT_BLOCK_ACCEPT_SIZE = 3.7e6;
 
 /**
  * Standard script verification flags that standard transactions will comply
@@ -67,7 +67,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason);
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
 
 namespace Policy {
-    std::int32_t blockSizeAcceptLimit();
+    std::uint32_t blockSizeAcceptLimit();
 }
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -144,7 +144,7 @@
              <number>1</number>
             </property>
             <property name="maximum">
-             <number>2147</number>
+             <number>4294</number>
             </property>
           </widget>
          </item>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -93,7 +93,7 @@ void OptionsModel::Init(bool resetSettings)
         addOverriddenOption("-par");
 
     if (!settings.contains("blockSizeAcceptLimitBytes"))
-        settings.setValue("blockSizeAcceptLimitBytes", static_cast<int32_t>(round(DEFAULT_BLOCK_ACCEPT_SIZE * 1e6)));
+        settings.setValue("blockSizeAcceptLimitBytes", DEFAULT_BLOCK_ACCEPT_SIZE);
     if (mapArgs.count("-blocksizeacceptlimit"))
         addOverriddenOption("-blocksizeacceptlimit");
     else if (mapArgs.count("-excessiveblocksize"))
@@ -234,7 +234,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case Listen:
             return settings.value("fListen");
         case BlockSizeAcceptLimit:
-            return settings.value("blockSizeAcceptLimitBytes").toInt() / 1e6;
+            return settings.value("blockSizeAcceptLimitBytes").toUInt() / 1e6;
         default:
             return QVariant();
         }
@@ -379,7 +379,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             }
             break;
         case BlockSizeAcceptLimit: {
-                int32_t valueBytes = round(value.toDouble() * 1e6);
+                uint32_t valueBytes = round(value.toDouble() * 1e6);
                 if (settings.value("blockSizeAcceptLimitBytes") != valueBytes) {
                     settings.setValue("blockSizeAcceptLimitBytes", valueBytes);
                     setRestartRequired(true);


### PR DESCRIPTION
There is some inconsistency with blockSizeAcceptLimit: sometimes it is treated as `int32_t`, and other places it is treated as `uint32_t`. This change makes all instances of the blockSizeAcceptLimit be `uint32_t`. In addition, this changes the `DEFAULT_BLOCK_ACCEPT_SIZE` constant from a `float` into a `uint32_t`.