### PR TITLE
Add -adminlisten program argument

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -437,6 +437,7 @@ static void addAdminServerOptions(AllowedArgs& allowedArgs)
         .addHeader("Admin server options: (Experimental!)")
         .addArg("adminserver", optionalBool, "Accept connections on the admin-server (default 0)")
         .addArg("admincookiefile=<loc>", requiredStr, "Location of the adminserver auth cookie (default: data dir)")
+        .addArg("adminlisten=<addr>", requiredStr, strprintf("Bind to given address to listen for admin server connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default 127.0.0.1:%s and [::1]:%s)", BaseParams(CBaseChainParams::MAIN).AdminServerPort(), BaseParams(CBaseChainParams::MAIN).AdminServerPort()));
         ;
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -24,6 +24,7 @@ public:
     CBaseMainParams()
     {
         nRPCPort = 8332;
+        nAdminServerPort = 1235;
     }
 };
 static CBaseMainParams mainParams;
@@ -37,6 +38,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 18332;
+        nAdminServerPort = 11235;
         strDataDir = "testnet3";
     }
 };
@@ -51,6 +53,7 @@ public:
     CBaseFTTestNetParams()
     {
         nRPCPort = 18334;
+        nAdminServerPort = 11236;
         strDataDir = "testnet-ft";
     }
 };
@@ -65,6 +68,7 @@ public:
     CBaseRegTestParams()
     {
         nRPCPort = 18332;
+        nAdminServerPort = 11235;
         strDataDir = "regtest";
     }
 };

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -23,11 +23,13 @@ public:
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
+    int AdminServerPort() const { return nAdminServerPort; }
 
 protected:
     CBaseChainParams() {}
 
     int nRPCPort;
+    int nAdminServerPort;
     std::string strDataDir;
 };
 


### PR DESCRIPTION
Resolves #208 

Creates a new program argument: `-adminlisten`. This argument can be specified multiple times in order to bind to multiple addresses. If the argument is not specified at all, then the admin server will listen on `127.0.0.1` and `[::1]` on the default port for the chain.

Also adds default Admin Server port to chainparamsbase.

If the host is not specified (e.g. `-adminlisten=:1237`), then the admin server will listen on that port on `127.0.0.1`. This is different that what was specified in the issue, which recommended listening on all interfaces (i.e. `0.0.0.0`) if the host was not specified. However, I feel that listening on localhost only by default is safer, because it prevents a user from inadvertently opening their node's admin server to external connections.

