### PR TITLE
Allow transaction sizes up to blockSizeAcceptLimit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -844,7 +844,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
     if (tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > (unsigned)Policy::blockSizeAcceptLimit())
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -185,9 +185,16 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
+namespace Policy {
+    static int32_t blockSizeAcceptLimitCached = -1;
+}
+
 int32_t Policy::blockSizeAcceptLimit()
 {
-    int limit = -1;
+    if (blockSizeAcceptLimitCached != -1)
+        return blockSizeAcceptLimitCached;
+
+    int32_t &limit = blockSizeAcceptLimitCached;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
     if (userlimit == mapArgs.end()) {
         limit = GetArg("-blocksizeacceptlimitbytes", -1);
@@ -209,4 +216,9 @@ int32_t Policy::blockSizeAcceptLimit()
     if (limit < 1000000)
         LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;
+}
+
+void Policy::resetBlockSizeAcceptLimitCache()
+{
+    blockSizeAcceptLimitCached = -1;
 }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -68,6 +68,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
 namespace Policy {
     std::int32_t blockSizeAcceptLimit();
+    void resetBlockSizeAcceptLimitCache();
 }
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -171,27 +171,34 @@ BOOST_AUTO_TEST_CASE(boolargno)
 
 BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)
 {
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-excessiveblocksize=5004000");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
 
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-blocksizeacceptlimitbytes=5004000");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
 
     // blocksizeacceptlimit always wins
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 
     // blocksizeacceptlimit always wins
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-blocksizeacceptlimitbytes=5004000 -blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 
     // blocksizeacceptlimitbytes always wins
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimitbytes=6004000");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 6004000);
 
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 
+    Policy::resetBlockSizeAcceptLimitCache();
     ResetArgs("-blocksizeacceptlimit=1.25");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -253,6 +253,43 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
     BOOST_CHECK_MESSAGE(!CheckTransaction(tx, state) || !state.IsValid(), "Transaction with duplicate txins should be invalid.");
 }
 
+BOOST_AUTO_TEST_CASE(large_valid_transaction)
+{
+    // Create a 1.001 MB transaction
+    string transaction = "010000000100010000000000000000000000000000000000000000000000000000000000000000000000ffffffff640000000000000000";
+    string outputPart = "fd14276a4d1027";
+    for (int i = 0; i < 20016; i++) {
+        outputPart += "0";
+    }
+    for (int i = 0; i < 100; i++) {
+        transaction += outputPart;
+    }
+    CDataStream stream(ParseHex(transaction), SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    stream >> tx;
+    CValidationState state;
+    BOOST_CHECK_MESSAGE(CheckTransaction(tx, state) && state.IsValid(), "Transaction greater than 1 MB should be valid by defualt.");
+
+}
+
+BOOST_AUTO_TEST_CASE(large_invalid_transaction)
+{
+    // Create a 4 MB transaction
+    string transaction = "010000000100010000000000000000000000000000000000000000000000000000000000000000000000fffffffffd90010000000000000000";
+    string outputPart = "fd14276a4d1027";
+    for (int i = 0; i < 20016; i++) {
+        outputPart += "0";
+    }
+    for (int i = 0; i < 400; i++) {
+        transaction += outputPart;
+    }
+    CDataStream stream(ParseHex(transaction), SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    stream >> tx;
+    CValidationState state;
+    BOOST_CHECK_MESSAGE(CheckTransaction(tx, state) || !state.IsValid(), "Transaction greater than 3.7 MB should not be valid by default.");
+}
+
 //
 // Helper: create two dummy transactions, each with
 // two outputs.  The first has 11 and 50 CENT outputs


### PR DESCRIPTION
Modify the CheckTransaction method to allow transactions to be as large as the user's blockSizeAcceptLimit, rather than the legacy MAX_BLOCK_SIZE.

Add additional tests which ensure transactions greater than 1 MB are valid by default, while transactions greater than 3.7 MB are not valid by default.

Additionally, modify Policy::blockSizeAcceptLimit to cache its return value so that parsing the command-line option is not necessary for every transaction.

Note that this is a change to consensus code. This change will allow Classic nodes to be compatible with Bitcoin Unlimited, which allows transactions of any size.