### PR TITLE
Remove maxVout restriction in bitcoin-tx

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -199,13 +199,10 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
         throw runtime_error("invalid TX input txid");
     uint256 txid(uint256S(strTxid));
 
-    static const unsigned int minTxOutSz = 9;
-    static const unsigned int maxVout = MAX_BLOCK_SIZE / minTxOutSz;
-
     // extract and validate vout
     string strVout = strInput.substr(pos + 1, string::npos);
     int vout = atoi(strVout);
-    if ((vout < 0) || (vout > (int)maxVout))
+    if (vout < 0)
         throw runtime_error("invalid TX input vout");
 
     // append to transaction input list


### PR DESCRIPTION
Allows any positive integer for an input's vout for transactions created with the bitcoin-tx tool. This is the same behavior as the createrawtransaction RPC call.

This removes all references to MAX_BLOCK_SIZE from the bitcoin-tx tool.