### PR TITLE
Adhere to BUIP 40 for max sigop consensus rules

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,8 +8,8 @@
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
-/** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+/** The maximum allowed number of signature check operations per megabyte in a block (network rule) */
+static const unsigned int MAX_BLOCK_SIGOPS_PER_MB = 20000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -251,9 +251,10 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
             if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
                 continue;
 
+            const uint64_t maxSigOps = Policy::blockSigOpAcceptLimit(nBlockSize + nTxSize);
             unsigned int nTxSigOps = iter->GetSigOpCount();
-            if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS) {
-                if (nBlockSigOps > MAX_BLOCK_SIGOPS - 2) {
+            if (nBlockSigOps + nTxSigOps >= maxSigOps) {
+                if (nBlockSigOps > maxSigOps - 2) {
                     break;
                 }
                 continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -144,7 +144,8 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
 
     std::priority_queue<CTxMemPool::txiter, std::vector<CTxMemPool::txiter>, ScoreCompare> clearedTxs;
     bool fPrintPriority = GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);
-    uint64_t nBlockSize = 1000;
+    const uint32_t nCoinbaseReserveSize = 1000;
+    uint64_t nBlockSize = nCoinbaseReserveSize;
     uint64_t nBlockTx = 0;
     unsigned int nBlockSigOps = 100;
     int lastFewTxs = 0;
@@ -251,7 +252,7 @@ CBlockTemplate* Mining::CreateNewBlock(const CChainParams& chainparams) const
             if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
                 continue;
 
-            const uint64_t maxSigOps = Policy::blockSigOpAcceptLimit(nBlockSize + nTxSize);
+            const uint64_t maxSigOps = Policy::blockSigOpAcceptLimit(nBlockSize + nTxSize - nCoinbaseReserveSize);
             unsigned int nTxSigOps = iter->GetSigOpCount();
             if (nBlockSigOps + nTxSigOps >= maxSigOps) {
                 if (nBlockSigOps > maxSigOps - 2) {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -186,6 +186,6 @@ int32_t Policy::blockSizeAcceptLimit()
 
 int64_t Policy::blockSigOpAcceptLimit(int32_t nBlockSize)
 {
-    uint64_t nBlockSizeMb = 1 + (nBlockSize - 1) / 1000000;
+    uint64_t nBlockSizeMb = 1 + ((nBlockSize - 1) / 1000000);
     return nBlockSizeMb * MAX_BLOCK_SIGOPS_PER_MB;
 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -183,3 +183,9 @@ int32_t Policy::blockSizeAcceptLimit()
         LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;
 }
+
+int64_t Policy::blockSigOpAcceptLimit(int32_t nBlockSize)
+{
+    uint64_t nBlockSizeMb = 1 + (nBlockSize - 1) / 1000000;
+    return nBlockSizeMb * MAX_BLOCK_SIGOPS_PER_MB;
+}

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -24,7 +24,7 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
+static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS_PER_MB/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
@@ -68,6 +68,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
 namespace Policy {
     std::int32_t blockSizeAcceptLimit();
+    std::int64_t blockSigOpAcceptLimit(int32_t nBlockSize);
 }
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -14,6 +14,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "pow.h"
 #include "rpcserver.h"
 #include "txmempool.h"
@@ -579,8 +580,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("sigoplimit", static_cast<int64_t>(MAX_BLOCK_SIGOPS)));
     int64_t sizeLimit = 32E6; // lets have a nice big default, the goal is to remove this from the API
+    result.push_back(Pair("sigoplimit", Policy::blockSigOpAcceptLimit(sizeLimit)));
     result.push_back(Pair("sizelimit", sizeLimit));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -69,12 +69,16 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
 BOOST_AUTO_TEST_CASE(blockSigOpAcceptLimit)
 {
     BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(0), 20000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(100), 20000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(50000), 20000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1e6), 20000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1e6 + 1), 40000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(2e6), 40000);
-    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(4e6 + 1), 100000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(70000), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(999999), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1000000), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1000001), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1700000), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1999999), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(2000000), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(2000001), 60000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(INT32_MAX), 42960000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "pubkey.h"
 #include "key.h"
+#include "policy/policy.h"
 #include "script/script.h"
 #include "script/standard.h"
 #include "uint256.h"
@@ -62,6 +63,18 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     CScript scriptSig2;
     scriptSig2 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << Serialize(s2);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), 3U);
+}
+
+
+BOOST_AUTO_TEST_CASE(blockSigOpAcceptLimit)
+{
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(0), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(100), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(50000), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1e6), 20000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(1e6 + 1), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(2e6), 40000);
+    BOOST_CHECK_EQUAL(Policy::blockSigOpAcceptLimit(4e6 + 1), 100000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
[BUIP 40](https://github.com/BitcoinUnlimited/BUIP/blob/master/040.mediawiki) outlines Bitcoin Unlimited's approach to dealing with sigop counts in blocks greater than 1 MB. This change will modify Bitcoin Classic so that it uses the same approach as Bitcoin Unlimited's default values when dealing with sigops in large blocks. This change does not add any additional configuration options for "excessive transaction size" or "excessive sigops per MB".

Adds a new Policy::blockSigOpAcceptLimit function, which calculates the maximum allowed sigops for a given block size. This rounds the block size up to the nearest MB, and then allows 20,000 sigops per
MB of blockspace.

Renames MAX_BLOCK_SIGOPS to MAX_BLOCK_SIGOPS_PER_MB, and defines it directly, rather than as a factor of MAX_BLOCK_SIZE.

Adds unit tests for Policy::blockSigOpAcceptLimit.

Updates the QA test p2p-fullblocktest.py to test the new sigop rules. Additionally modifies this test to create 2 MB blocks, which is required to test the new sigop behavior.

Note that this does not modify the MAX_STANDARD_TX_SIGOPS constant or make any modifications to what is considered a standard transaction.