### PR TITLE
Default argument value for checkmempool

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -347,7 +347,7 @@ static void addDebuggingOptions(AllowedArgs& allowedArgs, HelpMessageMode mode)
         .addHeader(_("Debugging/Testing options:"))
         .addArg("uacomment=<cmt>", requiredStr, _("Append comment to the user agent string"))
         .addDebugArg("checkblockindex", optionalBool, strprintf("Do a full consistency check for mapBlockIndex, setBlockIndexCandidates, chainActive and mapBlocksUnlinked occasionally (default: %u)", false))
-        .addDebugArg("checkmempool=<n>", requiredInt, strprintf("Run checks every <n> transactions (default: %u)", false))
+        .addDebugArg("checkmempool=<n>", requiredInt, strprintf("Run checks every <n> transactions (default: %u)", 0))
         .addDebugArg("checkpoints", optionalBool, strprintf("Disable expensive verification for known chain history (default: %u)", DEFAULT_CHECKPOINTS_ENABLED))
 #ifdef ENABLE_WALLET
         .addDebugArg("dblogsize=<n>", requiredInt, strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE))


### PR DESCRIPTION
To be more clear, use '0' instead of 'false' for the default value for checkmempool.