### PR TITLE
removing 'using namespace std;' from utilmoneystr

### DIFF
--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -9,8 +9,6 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-using namespace std;
-
 std::string FormatMoney(const CAmount& n)
 {
     // Note: not using straight sprintf here because we do NOT want

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -18,7 +18,7 @@ std::string FormatMoney(const CAmount& n)
     std::int64_t n_abs = (n > 0 ? n : -n);
     std::int64_t quotient = n_abs/COIN;
     std::int64_t remainder = n_abs%COIN;
-    string str = strprintf("%d.%08d", quotient, remainder);
+    std::string str = strprintf("%d.%08d", quotient, remainder);
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
@@ -33,14 +33,14 @@ std::string FormatMoney(const CAmount& n)
 }
 
 
-bool ParseMoney(const string& str, CAmount& nRet)
+bool ParseMoney(const std::string& str, CAmount& nRet)
 {
     return ParseMoney(str.c_str(), nRet);
 }
 
 bool ParseMoney(const char* pszIn, CAmount& nRet)
 {
-    string strWhole;
+    std::string strWhole;
     std::int64_t nUnits = 0;
     const char* p = pszIn;
     while (isspace(*p))

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -15,9 +15,9 @@ std::string FormatMoney(const CAmount& n)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
-    int64_t n_abs = (n > 0 ? n : -n);
-    int64_t quotient = n_abs/COIN;
-    int64_t remainder = n_abs%COIN;
+    std::int64_t n_abs = (n > 0 ? n : -n);
+    std::int64_t quotient = n_abs/COIN;
+    std::int64_t remainder = n_abs%COIN;
     string str = strprintf("%d.%08d", quotient, remainder);
 
     // Right-trim excess zeros before the decimal point:
@@ -41,7 +41,7 @@ bool ParseMoney(const string& str, CAmount& nRet)
 bool ParseMoney(const char* pszIn, CAmount& nRet)
 {
     string strWhole;
-    int64_t nUnits = 0;
+    std::int64_t nUnits = 0;
     const char* p = pszIn;
     while (isspace(*p))
         p++;
@@ -50,7 +50,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         if (*p == '.')
         {
             p++;
-            int64_t nMult = CENT*10;
+            std::int64_t nMult = CENT*10;
             while (isdigit(*p) && (nMult > 0))
             {
                 nUnits += nMult * (*p++ - '0');
@@ -71,7 +71,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         return false;
     if (nUnits < 0 || nUnits > COIN)
         return false;
-    int64_t nWhole = atoi64(strWhole);
+    std::int64_t nWhole = atoi64(strWhole);
     CAmount nValue = nWhole*COIN + nUnits;
 
     nRet = nValue;

--- a/src/utilmoneystr.h
+++ b/src/utilmoneystr.h
@@ -9,7 +9,7 @@
 #ifndef BITCOIN_UTILMONEYSTR_H
 #define BITCOIN_UTILMONEYSTR_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "amount.h"


### PR DESCRIPTION
Here's a small start at addressing the pervasive use of 'using namespace std;' and C-like namespacing that @zander mentions in #210. Seems to compile and test fine with the changes. If this is helpful I'd be happy to go over some more of the codebase over the next few weeks.