### PR TITLE
Forward declaration inconsistency warning fix

### DIFF
--- a/src/test/transaction_utils.h
+++ b/src/test/transaction_utils.h
@@ -10,7 +10,7 @@
 
 class CScript;
 struct CMutableTransaction;
-struct CTransaction;
+class CTransaction;
 
 namespace TxUtils {
     void RandomScript(CScript &script);


### PR DESCRIPTION
Removes compilation warning:
`warning: struct 'CTransaction' was previously declared as a class'`