### PR TITLE
remove unused inconsistently defined protocol upgrade activation parameters

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,10 +143,6 @@ public:
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
         // Timestamps for forking consensus rule changes:
-        // Allow bigger blocks if:
-        consensus.nActivateSizeForkMajority = 750; // 75% of hashpower to activate fork
-        consensus.nSizeForkGracePeriod = 60*60*24*28; // four week grace period after activation
-        consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -262,9 +258,6 @@ public:
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
 
-        consensus.nActivateSizeForkMajority = 75; // 75 of 100 to activate fork
-        consensus.nSizeForkGracePeriod = 60*60*24; // 1-day grace period
-        consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
         assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
@@ -385,9 +378,6 @@ public:
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        consensus.nActivateSizeForkMajority = 75; // 75 of 100 to activate fork
-        consensus.nSizeForkGracePeriod = 60*60*24; // 1-day grace period
-        consensus.nSizeForkExpiration = 1514764800; // 2018-01-01 00:00:00 GMT
         assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -64,11 +64,6 @@ struct Params {
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
-
-    /** remove blocksize-limit protocol-upgrade activation parameters */
-    int nActivateSizeForkMajority;
-    int64_t nSizeForkGracePeriod;
-    int64_t nSizeForkExpiration;
 };
 } // namespace Consensus
 


### PR DESCRIPTION
unused params.
Also weirdly used, in one place `consensus.nActivateSizeForkMajority = 750` in another it as set to `75`